### PR TITLE
replaced OpXToMulti subclassing

### DIFF
--- a/lazyflow/operators/__init__.py
+++ b/lazyflow/operators/__init__.py
@@ -24,6 +24,11 @@ except:
     from opColorizeLabels import OpColorizeLabels
     from opObjectFeatures import OpObjectFeatures
 
+    # necessary because we used a factory
+    from obsolete.vigraOperators import \
+        Op1ToMulti, Op5ToMulti, Op10ToMulti, \
+        Op20ToMulti, Op50ToMulti
+
     ops = itersubclasses(Operator)
     logger.debug("Loading default Operators...")
     loaded = ""


### PR DESCRIPTION
While debugging ilastik/ilastik#93 I noticed that OpXToMulti is sub-classed a bunch of times, only to change the number of input slots. So I wrote a factory for it instead. I also refactored its methods to remove code duplication.
