### PR TITLE
fixed failing testOpStackWriter

### DIFF
--- a/lazyflow/operators/ioOperators/ioOperators.py
+++ b/lazyflow/operators/ioOperators/ioOperators.py
@@ -194,7 +194,7 @@ class OpStackWriter(Operator):
                 patternEntries = iterationIndexDescriptors
                 
                 fullFilename = filepath + filepattern % (patternEntries)
-                vigra.impex.writeImage(data.reshape(*newImageShape).transpose(self.transposing), fullFilename)
+                vigra.impex.writeImage(data.reshape(newImageShape).transpose(self.transposing), fullFilename)
                 
                 req.clean() # Discard the data in the request and allow its children to be garbage collected.
 


### PR DESCRIPTION
The usage 

``` python
a.reshape(*tuple())
```

is afaik not officially supported (see http://docs.scipy.org/doc/numpy/reference/generated/numpy.reshape.html, which is the method that is inherited). The shape should not be expanded with the asterisk.
