### PR TITLE
fix import dvidclient bug

### DIFF
--- a/lazyflow/operators/ioOperators/opExportSlot.py
+++ b/lazyflow/operators/ioOperators/opExportSlot.py
@@ -16,7 +16,7 @@ try:
     from lazyflow.operators.ioOperators import OpExportDvidVolume
     _supports_dvid = True
 except ImportError as ex:
-    if 'OpDvidVolume' not in ex.args[0]:
+    if 'OpDvidVolume' not in ex.args[0] and 'OpExportDvidVolume' not in ex.args[0]:
         raise
     _supports_dvid = False
 


### PR DESCRIPTION
I was getting the error below because `import dvidclient` in `ioOperators/__init__.py` is failing silently, but the error message check in `ioOperators/opExportSlot.py` is not enough to catch the ImportError.

```
File ".../lazyflow/lazyflow/operators/ioOperators/opExportSlot.py", line 16, in <module>
    from lazyflow.operators.ioOperators import OpExportDvidVolume
ImportError: cannot import name OpExportDvidVolume
```
