### PR TITLE
Masked arrays i.e. Handle frames of variable size (with known maximum) (pt. 2)

### DIFF
--- a/lazyflow/operators/generic.py
+++ b/lazyflow/operators/generic.py
@@ -511,9 +511,9 @@ class OpSubRegion(Operator):
     - Always propagates dirty state.
     - Simpler implementation...
     """
-    Input = InputSlot()
+    Input = InputSlot(allow_mask=True)
     Roi = InputSlot() # value slot. value is a tuple: (start, stop)
-    Output = OutputSlot()
+    Output = OutputSlot(allow_mask=True)
 
     def setupOutputs(self):
         self._roi = self.Roi.value

--- a/lazyflow/operators/opArrayCache.py
+++ b/lazyflow/operators/opArrayCache.py
@@ -63,13 +63,13 @@ class OpArrayCache(OpCache):
     DefaultBlockSize = 64
 
     #Input
-    Input = InputSlot()
+    Input = InputSlot(allow_mask=True)
     blockShape = InputSlot(value = DefaultBlockSize)
     fixAtCurrent = InputSlot(value = False)
    
     #Output
     CleanBlocks = OutputSlot()
-    Output = OutputSlot()
+    Output = OutputSlot(allow_mask=True)
 
     loggingName = __name__ + ".OpArrayCache"
     logger = logging.getLogger(loggingName)

--- a/lazyflow/operators/opArrayPiper.py
+++ b/lazyflow/operators/opArrayPiper.py
@@ -26,10 +26,10 @@ class OpArrayPiper(Operator):
     description = "simple piping operator"
 
     #Inputs
-    Input = InputSlot()
+    Input = InputSlot(allow_mask=True)
    
     #Outputs
-    Output = OutputSlot()
+    Output = OutputSlot(allow_mask=True)
 
     def setupOutputs(self):
         inputSlot = self.inputs["Input"]

--- a/lazyflow/operators/opBlockedArrayCache.py
+++ b/lazyflow/operators/opBlockedArrayCache.py
@@ -45,14 +45,14 @@ class OpBlockedArrayCache(OpCache):
     description = ""
 
     #Input
-    Input = InputSlot()
+    Input = InputSlot(allow_mask=True)
     innerBlockShape = InputSlot()
     outerBlockShape = InputSlot()
     fixAtCurrent = InputSlot()
     forward_dirty = InputSlot(value = True)
    
     #Output
-    Output = OutputSlot("Output")
+    Output = OutputSlot("Output", allow_mask=True)
 
     loggerName = __name__ + ".OpBlockedArrayCache"
     logger = logging.getLogger(loggerName)

--- a/lazyflow/operators/opCompressedCache.py
+++ b/lazyflow/operators/opCompressedCache.py
@@ -44,14 +44,14 @@ class OpCompressedCache(OpCache):
     
     Note: It is not safe to call execute() change the blockshape simultaneously.
     """
-    Input = InputSlot() # Also used to asynchronously force data into the cache via __setitem__ (see setInSlot(), below()
+    Input = InputSlot(allow_mask=True) # Also used to asynchronously force data into the cache via __setitem__ (see setInSlot(), below()
     BlockShape = InputSlot(optional=True) # If not provided, the entire input is treated as one block
     
-    Output = OutputSlot() # Output as numpy arrays
+    Output = OutputSlot(allow_mask=True) # Output as numpy arrays
 
-    InputHdf5 = InputSlot(optional=True)
+    InputHdf5 = InputSlot(optional=True, allow_mask=True)
     CleanBlocks = OutputSlot() # A list of rois (tuples) of the blocks that are currently stored in the cache
-    OutputHdf5 = OutputSlot() # Provides data as hdf5 datasets.  Only allowed for rois that exactly match a block.
+    OutputHdf5 = OutputSlot(allow_mask=True) # Provides data as hdf5 datasets.  Only allowed for rois that exactly match a block.
     
     def __init__(self, *args, **kwargs):
         super( OpCompressedCache, self ).__init__( *args, **kwargs )

--- a/lazyflow/operators/opCompressedUserLabelArray.py
+++ b/lazyflow/operators/opCompressedUserLabelArray.py
@@ -54,17 +54,17 @@ class OpCompressedUserLabelArray(OpCompressedCache):
     nonzeroBlocks = OutputSlot()
     #maxLabel = OutputSlot()
     
-    Projection2D = OutputSlot() # A somewhat magic output that returns a projection of all 
-                                # label data underneath a given roi, from all slices.
-                                # If, for example, a 256x1x256 tile is requested from this slot,
-                                # It will return a projection of ALL labels that fall within the 256 x ... x 256 tile.
-                                # (The projection axis is *inferred* from the shape of the requested data).
-                                # The projection data is float32 between 0.0 and 1.0, where:
-                                # - Exactly 0.0 means "no labels under this pixel"
-                                # - 1/256.0 means "labels in the first slice"
-                                # - ...
-                                # - 1.0 means "last slice"
-                                # The output is suitable for display in a colortable.
+    Projection2D = OutputSlot(allow_mask=True) # A somewhat magic output that returns a projection of all
+                                               # label data underneath a given roi, from all slices.
+                                               # If, for example, a 256x1x256 tile is requested from this slot,
+                                               # It will return a projection of ALL labels that fall within the 256 x ... x 256 tile.
+                                               # (The projection axis is *inferred* from the shape of the requested data).
+                                               # The projection data is float32 between 0.0 and 1.0, where:
+                                               # - Exactly 0.0 means "no labels under this pixel"
+                                               # - 1/256.0 means "labels in the first slice"
+                                               # - ...
+                                               # - 1.0 means "last slice"
+                                               # The output is suitable for display in a colortable.
     
     def __init__(self, *args, **kwargs):
         super(OpCompressedUserLabelArray, self).__init__( *args, **kwargs )

--- a/lazyflow/operators/opCompressedUserLabelArray.py
+++ b/lazyflow/operators/opCompressedUserLabelArray.py
@@ -144,21 +144,7 @@ class OpCompressedUserLabelArray(OpCompressedCache):
         for block_roi in stored_block_rois:
             # Get data
             block_shape = numpy.subtract( block_roi[1], block_roi[0] )
-            block = numpy.ndarray( shape=block_shape, dtype=self.Output.meta.dtype )
-
-            if self.Output.meta.has_mask:
-                block_fill_value = None
-                if issubclass(block.dtype.type, numpy.integer):
-                    block_fill_value = block.dtype.type(numpy.iinfo(block.dtype.type).max)
-                elif issubclass(block.dtype.type, numpy.floating):
-                    block_fill_value = block.dtype.type(numpy.nan)
-
-                block = numpy.ma.masked_array(
-                    block,
-                    mask=numpy.ma.getmaskarray(block),
-                    fill_value=block_fill_value,
-                    shrink=False
-                )
+            block = self.Output.stype.allocateDestination(SubRegion(self.Output, *roiFromShape(block_shape)))
 
             self.execute(self.Output, (), SubRegion( self.Output, *block_roi ), block)
 
@@ -391,21 +377,7 @@ class OpCompressedUserLabelArray(OpCompressedCache):
         """
 
         # Extract the data to modify
-        original_data = numpy.ndarray( shape=new_pixels.shape, dtype=self.Output.meta.dtype )
-        # Use masked array if that is what Output expects.
-        if self.Output.meta.has_mask:
-            original_data_fill_value = None
-            if issubclass(original_data.dtype.type, numpy.integer):
-                original_data_fill_value = original_data.dtype.type(numpy.iinfo(original_data.dtype.type).max)
-            elif issubclass(original_data.dtype.type, numpy.floating):
-                original_data_fill_value = original_data.dtype.type(numpy.nan)
-
-            original_data = numpy.ma.masked_array(
-                original_data,
-                mask=numpy.ma.getmaskarray(original_data),
-                fill_value=original_data_fill_value,
-                shrink=False
-            )
+        original_data = self.Output.stype.allocateDestination(SubRegion(self.Output, *roiFromShape(new_pixels.shape)))
 
         self.execute(self.Output, (), roi, original_data)
         

--- a/lazyflow/operators/opFillMaskArray.py
+++ b/lazyflow/operators/opFillMaskArray.py
@@ -1,0 +1,27 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#		   http://ilastik.org/license/
+###############################################################################
+
+__author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
+__date__ = "$Feb 26, 2015 11:47:00 EST$"
+
+
+

--- a/lazyflow/operators/opFillMaskArray.py
+++ b/lazyflow/operators/opFillMaskArray.py
@@ -25,3 +25,49 @@ __date__ = "$Feb 26, 2015 11:47:00 EST$"
 
 
 
+import numpy
+
+from lazyflow.operator import Operator
+from lazyflow.slot import InputSlot, OutputSlot
+
+
+class OpFillMaskArray(Operator):
+    name = "OpFillMaskArray"
+    category = "Pointwise"
+
+
+    InputArray = InputSlot()
+    InputFillValue = InputSlot()
+
+    Output = OutputSlot()
+
+    def __init__(self, *args, **kwargs):
+        super( OpFillMaskArray, self ).__init__( *args, **kwargs )
+
+    def setupOutputs(self):
+        # Copy the input metadata to both outputs
+        self.Output.meta.assignFrom( self.InputArray.meta )
+        self.Output.meta.has_mask = False
+
+    def execute(self, slot, subindex, roi, result):
+        key = roi.toSlice()
+
+        # Get data
+        data = self.InputArray[key].wait()
+        value = self.InputFillValue.value
+
+        # Make a masked array
+        data = data.view(numpy.ma.masked_array)
+
+        # Copy results
+        if slot.name == 'Output':
+            result[...] = data.filled(value)
+
+    def propagateDirty(self, slot, subindex, roi):
+        if (slot.name == "InputArray"):
+            slicing = roi.toSlice()
+            self.Output.setDirty(slicing)
+        elif (slot.name == "InputFillValue"):
+            self.Output.setDirty(slice(None))
+        else:
+            assert False, "Unknown dirty input slot"

--- a/lazyflow/operators/opFillMaskArray.py
+++ b/lazyflow/operators/opFillMaskArray.py
@@ -56,12 +56,12 @@ class OpFillMaskArray(Operator):
         data = self.InputArray[key].wait()
         value = self.InputFillValue.value
 
-        # Make a masked array
-        data = data.view(numpy.ma.masked_array)
-
         # Copy results
         if slot.name == 'Output':
-            result[...] = data.filled(value)
+            if not isinstance(data, numpy.ma.masked_array):
+                result[...] = data
+            else:
+                result[...] = data.filled(value)
 
     def propagateDirty(self, slot, subindex, roi):
         if (slot.name == "InputArray"):

--- a/lazyflow/operators/opFillMaskArray.py
+++ b/lazyflow/operators/opFillMaskArray.py
@@ -37,7 +37,7 @@ class OpFillMaskArray(Operator):
 
 
     InputArray = InputSlot()
-    InputFillValue = InputSlot()
+    InputFillValue = InputSlot(optional=True)
 
     Output = OutputSlot()
 
@@ -54,14 +54,15 @@ class OpFillMaskArray(Operator):
 
         # Get data
         data = self.InputArray[key].wait()
-        value = self.InputFillValue.value
 
         # Copy results
         if slot.name == 'Output':
             if not isinstance(data, numpy.ma.masked_array):
                 result[...] = data
+            elif self.InputFillValue.ready():
+                result[...] = data.filled(self.InputFillValue.value)
             else:
-                result[...] = data.filled(value)
+                result[...] = data.filled()
 
     def propagateDirty(self, slot, subindex, roi):
         if (slot.name == "InputArray"):

--- a/lazyflow/operators/opFillMaskArray.py
+++ b/lazyflow/operators/opFillMaskArray.py
@@ -36,7 +36,7 @@ class OpFillMaskArray(Operator):
     category = "Pointwise"
 
 
-    InputArray = InputSlot()
+    InputArray = InputSlot(allow_mask=True)
     InputFillValue = InputSlot(optional=True)
 
     Output = OutputSlot()

--- a/lazyflow/operators/opMaskArray.py
+++ b/lazyflow/operators/opMaskArray.py
@@ -36,10 +36,10 @@ class OpMaskArray(Operator):
     category = "Pointwise"
 
 
-    InputArray = InputSlot()
+    InputArray = InputSlot(allow_mask=True)
     InputMask = InputSlot()
 
-    Output = OutputSlot()
+    Output = OutputSlot(allow_mask=True)
 
     def __init__(self, *args, **kwargs):
         super( OpMaskArray, self ).__init__( *args, **kwargs )

--- a/lazyflow/operators/opSlicedBlockedArrayCache.py
+++ b/lazyflow/operators/opSlicedBlockedArrayCache.py
@@ -39,14 +39,14 @@ class OpSlicedBlockedArrayCache(OpCache):
     description = ""
 
     #Inputs
-    Input = InputSlot()
+    Input = InputSlot(allow_mask=True)
     innerBlockShape = InputSlot()
     outerBlockShape = InputSlot()
     fixAtCurrent = InputSlot(value = False)
    
     #Outputs
-    Output = OutputSlot()
-    InnerOutputs = OutputSlot(level=1)
+    Output = OutputSlot(allow_mask=True)
+    InnerOutputs = OutputSlot(level=1, allow_mask=True)
 
     loggerName = __name__ + ".OpSlicedBlockedArrayCache"
     logger = logging.getLogger(loggerName)

--- a/lazyflow/operators/opSplitMaskArray.py
+++ b/lazyflow/operators/opSplitMaskArray.py
@@ -35,7 +35,7 @@ class OpSplitMaskArray(Operator):
     name = "OpSplitMaskArray"
     category = "Pointwise"
 
-    Input = InputSlot()
+    Input = InputSlot(allow_mask=True)
 
     OutputArray = OutputSlot()
     OutputMask = OutputSlot()

--- a/lazyflow/operators/opSplitMaskArray.py
+++ b/lazyflow/operators/opSplitMaskArray.py
@@ -1,0 +1,27 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#		   http://ilastik.org/license/
+###############################################################################
+
+__author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
+__date__ = "$Feb 27, 2015 09:51:01 EST$"
+
+
+

--- a/lazyflow/operators/opSplitMaskArray.py
+++ b/lazyflow/operators/opSplitMaskArray.py
@@ -25,3 +25,55 @@ __date__ = "$Feb 27, 2015 09:51:01 EST$"
 
 
 
+import numpy
+
+from lazyflow.operator import Operator
+from lazyflow.slot import InputSlot, OutputSlot
+
+
+class OpSplitMaskArray(Operator):
+    name = "OpSplitMaskArray"
+    category = "Pointwise"
+
+    Input = InputSlot()
+
+    OutputArray = OutputSlot()
+    OutputMask = OutputSlot()
+    OutputFillValue = OutputSlot()
+
+    def __init__(self, *args, **kwargs):
+        super( OpSplitMaskArray, self ).__init__( *args, **kwargs )
+
+    def setupOutputs(self):
+        # Copy the input metadata to both outputs
+        self.OutputArray.meta.assignFrom( self.Input.meta )
+        self.OutputArray.meta.has_mask = False
+
+        self.OutputMask.meta.assignFrom( self.Input.meta )
+        self.OutputMask.meta.has_mask = False
+        self.OutputMask.meta.dtype = numpy.bool8
+
+        self.OutputFillValue.meta.assignFrom( self.Input.meta )
+        self.OutputFillValue.meta.has_mask = False
+        self.OutputFillValue.meta.shape = tuple()
+
+    def execute(self, slot, subindex, roi, result):
+        key = roi.toSlice()
+
+        input_subview = self.Input[key].wait()
+
+        if slot.name == 'OutputArray':
+            result[...] = input_subview.data
+        elif slot.name == 'OutputMask':
+            result[...] = input_subview.mask
+        elif slot.name == 'OutputFillValue':
+            result[...] = input_subview.fill_value
+
+    def propagateDirty(self, slot, subindex, roi):
+        if (slot.name == "Input"):
+            slicing = roi.toSlice()
+            self.OutputArray.setDirty(slicing)
+            self.OutputMask.setDirty(slicing)
+            self.OutputFillValue.setDirty(Ellipsis)
+        else:
+            assert False, "Unknown dirty input slot"

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -163,6 +163,12 @@ class Slot(object):
         # This assertion is here for a reason: default values do NOT work on OutputSlots.
         # (We should probably change that at some point...)
         assert value is None or isinstance(self, InputSlot), "Only InputSlots can have default values.  OutputSlots cannot."
+
+        # If we do not support masked arrays, ensure that we are not being passed one.
+        assert allow_mask or not isinstance(value, numpy.ma.masked_array), \
+            "The operator, \"%s\", is being setup to receive a masked array as input to slot, \"%s\"." \
+            " This is currently not supported." \
+            % (self.operator.name, self.name)
         
         # Check for simple mistakes in parameter order...
         assert isinstance(name, str)

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -22,6 +22,7 @@
 #Python
 import sys
 import logging
+import collections
 import itertools
 import threading
 import functools
@@ -81,7 +82,8 @@ class ValueRequest(object):
             destination.mask[...] = numpy.ma.getmaskarray(self.result)
             if isinstance(self.result, numpy.ma.masked_array):
                 destination.fill_value = self.result.fill_value
-        elif isinstance(destination, (list, tuple)) or isinstance(self.result, (list, tuple)):
+        elif isinstance(destination, collections.MutableSequence) or \
+             isinstance(self.result, collections.MutableSequence):
             destination[:] = self.result[:]
         else:
             destination[...] = self.result[...]

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -449,6 +449,10 @@ class Slot(object):
             assert isinstance(partner, Slot), ("Slot.connect() can only be used to"
                                                " connect other Slots.  Did you mean"
                                                " to use Slot.setValue()?")
+            assert self.allow_mask or (not partner.meta.has_mask), \
+                        "The operator, \"%s\", is being setup to receive a masked array as input to slot, \"%s\"," \
+                        " from the output slot, \"%s\", on operator, \"%s\". This is currently not supported." \
+                        % (self.operator.name, self.name, self.partner.name, self.partner.operator.name)
 
             my_op = self.getRealOperator()
             partner_op = partner.getRealOperator()

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -452,7 +452,7 @@ class Slot(object):
             assert self.allow_mask or (not partner.meta.has_mask), \
                         "The operator, \"%s\", is being setup to receive a masked array as input to slot, \"%s\"," \
                         " from the output slot, \"%s\", on operator, \"%s\". This is currently not supported." \
-                        % (self.operator.name, self.name, self.partner.name, self.partner.operator.name)
+                        % (self.operator.name, self.name, partner.name, partner.operator.name)
 
             my_op = self.getRealOperator()
             partner_op = partner.getRealOperator()

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -134,7 +134,7 @@ class Slot(object):
     
     def __init__(self, name="", operator=None, stype=ArrayLike,
                  rtype=rtype.SubRegion, value=None, optional=False,
-                 level=0, nonlane=False):
+                 level=0, nonlane=False, allow_mask=False):
         """Constructor of the Slot class.
 
         :param name: user readable name of the slot, is normally
@@ -176,6 +176,7 @@ class Slot(object):
         self.name = name
         self._optional = optional
         self.operator = operator
+        self.allow_mask = allow_mask
         self._real_operator = None # Memoized in getRealOperator()
 
         # in the case of an InputSlot this is the slot to which it is

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -1085,6 +1085,12 @@ class Slot(object):
                 if isinstance(value, numpy.ndarray) or isinstance(self._value, numpy.ndarray):
                     if type(value) != type(self._value) or value.shape != self._value.shape:
                         changed = True
+                if isinstance(value, numpy.ma.masked_array) and isinstance(self._value, numpy.ma.masked_array):
+                    # Type comparison already checked as all masked arrays are subclasses of ndarrays.
+                    # NAN does not compare equal so we need a way to check that separately.
+                    if (value.fill_value != self._value.fill_value) and \
+                        not (numpy.isnan(value.fill_value) and numpy.isnan(self._value.fill_value)):
+                        changed = True
                 if isinstance(value, vigra.VigraArray) or isinstance(self._value, vigra.VigraArray):
                     if type(value) != type(self._value) or value.axistags != self._value.axistags:
                         changed = True

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -1087,6 +1087,12 @@ class Slot(object):
             # passing slots as values, then this assertion can be refined.
             assert not isinstance(value, Slot), \
                 "When using setValue, value cannot be a slot.  Use connect instead."
+
+            # If we do not support masked arrays, ensure that we are not being passed one.
+            assert self.allow_mask or not (self.meta.has_mask or isinstance(value, numpy.ma.masked_array)), \
+                "The operator, \"%s\", is being setup to receive a masked array as input to slot, \"%s\"." \
+                " This is currently not supported." \
+                % (self.operator.name, self.name)
     
             if not self.backpropagate_values:
                 assert self.partner is None, \

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -1355,6 +1355,10 @@ class Slot(object):
 
         wasdirty = self.meta._dirty
         if self.meta._dirty:
+            assert self.allow_mask or (not self.meta.has_mask), \
+                "The operator, \"%s\", is being setup to receive a masked array as input to slot, \"%s\"." \
+                " This is currently not supported." \
+                % (self.operator.name, self.name)
             for c in self.partners:
                 c._changed()
             self.meta._dirty = False

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -1015,6 +1015,11 @@ class Slot(object):
         this setInSlot() method.
 
         """
+        # If we do not support masked arrays, ensure that we are not being passed one.
+        assert self.allow_mask or not (self.meta.has_mask or isinstance(value, numpy.ma.masked_array)), \
+            "The operator, \"%s\", is being setup to receive a masked array as input to slot, \"%s\"." \
+            " This is currently not supported." \
+            % (self.operator.name, self.name)
         # Determine which subslot this is and prepend it to the totalIndex
         totalIndex = (self._subSlots.index(slot),) + subindex
         # Forward the call to our operator

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -986,6 +986,11 @@ class Slot(object):
             "cannot do __setitem__ on Slot '{}' -> no operator !!"
         assert slicingtools.is_bounded(key), \
             "Can't use Slot.__setitem__ with keys that include : or ..."
+        # If we do not support masked arrays, ensure that we are not being passed one.
+        assert self.allow_mask or not (self.meta.has_mask or isinstance(value, numpy.ma.masked_array)), \
+            "The operator, \"%s\", is being setup to receive a masked array as input to slot, \"%s\"." \
+            " This is currently not supported." \
+            % (self.operator.name, self.name)
         roi = self.rtype(self, pslice=key)
         if self._value is not None:
             self._value[key] = value

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -1298,6 +1298,7 @@ class Slot(object):
         init_kwargs['value'] = self._defaultValue
         init_kwargs['level'] = self.level
         init_kwargs['nonlane'] = self.nonlane
+        init_kwargs['allow_mask'] = self.allow_mask
         if self._type == "input":
             init_kwargs['optional'] = self._optional
         

--- a/lazyflow/stype.py
+++ b/lazyflow/stype.py
@@ -110,7 +110,7 @@ class ArrayLike( SlotType ):
             storage_mask = numpy.zeros(storage.shape, dtype=bool)
             storage_fill_value = None
             if issubclass(storage.dtype.type, numpy.integer):
-                storage_fill_value = storage.dtype.type(numpy.iinfo(storage.dtype.type).max)
+                storage_fill_value = storage.dtype.type(0)
             elif issubclass(storage.dtype.type, numpy.floating):
                 storage_fill_value = storage.dtype.type(numpy.nan)
             elif issubclass(storage.dtype.type, numpy.complexfloating):

--- a/lazyflow/stype.py
+++ b/lazyflow/stype.py
@@ -127,6 +127,14 @@ class ArrayLike( SlotType ):
         return storage
 
     def writeIntoDestination( self, destination, value, roi ):
+        # If we do not support masked arrays, ensure that we are not being passed one.
+        assert self.slot.allow_mask or (not self.slot.meta.has_mask), \
+            "A masked array was provided as a destination. However," \
+            " the slot, \"%s\", of operator, " "\"%s\", does not support masked arrays." \
+            " If you believe this message to be incorrect, " \
+            "please pass the keyword argument `allow_mask=True` to the slot constructor." \
+            % (self.slot.operator.name, self.slot.name)
+
         if destination is not None:
             if not isinstance(destination, list):
                 assert(roi.dim == destination.ndim), "%r ndim=%r, shape=%r" % (roi.toSlice(), destination.ndim, destination.shape)

--- a/lazyflow/stype.py
+++ b/lazyflow/stype.py
@@ -20,6 +20,7 @@
 #		   http://ilastik.org/license/
 ###############################################################################
 import numpy, vigra
+import collections
 import warnings
 
 from roi import roiToSlice
@@ -200,7 +201,8 @@ class ArrayLike( SlotType ):
             dst.mask[...] = numpy.ma.getmaskarray(src_val)
             if isinstance(src_val, numpy.ma.masked_array):
                 dst.fill_value = src_val.fill_value
-        elif isinstance(dst, (list, tuple)) or isinstance(src, (list, tuple)):
+        elif isinstance(dst, collections.MutableSequence) or \
+                isinstance(src, collections.MutableSequence):
             dst[:] = src[:]
         else:
             dst[...] = src[...]

--- a/lazyflow/stype.py
+++ b/lazyflow/stype.py
@@ -109,7 +109,7 @@ class ArrayLike( SlotType ):
         if self.slot.meta.has_mask:
             storage_mask = numpy.zeros(storage.shape, dtype=bool)
             storage_fill_value = None
-            if issubclass(storage.dtype.type, numpy.integer):
+            if issubclass(storage.dtype.type, (numpy.bool8, numpy.integer)):
                 storage_fill_value = storage.dtype.type(0)
             elif issubclass(storage.dtype.type, numpy.floating):
                 storage_fill_value = storage.dtype.type(numpy.nan)

--- a/lazyflow/stype.py
+++ b/lazyflow/stype.py
@@ -98,6 +98,13 @@ class SlotType( object ):
 
 class ArrayLike( SlotType ):
     def allocateDestination( self, roi ):
+        # If we do not support masked arrays, ensure that we are not allocating one.
+        assert self.slot.allow_mask or (not self.slot.meta.has_mask), \
+            "Allocation of a masked array is expected by the slot, \"%s\", of operator, " "\"%s\"," \
+            " even though it is not supported. If you believe this message to be incorrect, " \
+            "please pass the keyword argument `allow_mask=True` to the slot constructor." \
+            % (self.slot.operator.name, self.slot.name)
+
         shape = roi.stop - roi.start if roi else self.slot.meta.shape
         storage = numpy.ndarray(shape, dtype=self.slot.meta.dtype)
 

--- a/lazyflow/utility/testing.py
+++ b/lazyflow/utility/testing.py
@@ -76,8 +76,8 @@ class OpArrayPiperWithAccessCount(Operator):
     """
     array piper that counts how many times its execute function has been called
     """
-    Input = InputSlot()
-    Output = OutputSlot()
+    Input = InputSlot(allow_mask=True)
+    Output = OutputSlot(allow_mask=True)
 
     def __init__(self, *args, **kwargs):
         super(OpArrayPiperWithAccessCount, self).__init__(*args, **kwargs)

--- a/tests/testOpArrayCache.py
+++ b/tests/testOpArrayCache.py
@@ -455,7 +455,7 @@ class TestOpArrayCache_masked(object):
         # but fixAtCurrent is True so the cache gives us zeros
         assert (data == 0).all()
         assert (data.mask == False).all()
-        assert (data.fill_value == numpy.iinfo(numpy.int_).max).all()
+        assert (data.fill_value == 0).all()
 
         opCache.fixAtCurrent.setValue(False)
 

--- a/tests/testOpArrayCache.py
+++ b/tests/testOpArrayCache.py
@@ -324,9 +324,13 @@ class TestOpArrayCache_setInSlot(object):
         data = vigra.taggedView(data, 'xy')
         op = OpArrayCache(graph=Graph())
         op.Input.setValue(data)
+
+        assert (op.Output[0:20,0:20].wait() == 0).all()
         
         # Should not crash...
         op.Input[0:20,0:20] = numpy.ones((20,20))
+
+        assert (op.Output[0:20,0:20].wait() == 1).all()
 
 class TestOpArrayCache_masked(object):
 

--- a/tests/testOpArrayPiper.py
+++ b/tests/testOpArrayPiper.py
@@ -136,7 +136,6 @@ class TestOpArrayPiper3(object):
         self.operator_identity = OpArrayPiper(graph=self.graph)
 
         self.operator_identity.Input.meta.axistags = vigra.AxisTags("txyzc")
-        self.operator_identity.Input.meta.has_mask = True
 
     def test1(self):
         # Generate a random dataset and see if it we get the right masking from the operator.

--- a/tests/testOpArrayPiper.py
+++ b/tests/testOpArrayPiper.py
@@ -298,14 +298,6 @@ class TestOpArrayPiper4(object):
         except AssertionError as e:
             raise AllowMaskException(str(e))
 
-        assert(self.operator_identity.Input.meta.has_mask)
-        assert(self.operator_identity.Output.meta.has_mask)
-        output = self.operator_identity.Output[None].wait()
-
-        assert((data == output).all())
-        assert(data.mask.shape == output.mask.shape)
-        assert((data.mask == output.mask).all())
-
     @nose.tools.raises(AllowMaskException)
     def test2(self):
         # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
@@ -327,16 +319,6 @@ class TestOpArrayPiper4(object):
         except AssertionError as e:
             raise AllowMaskException(str(e))
 
-        assert(self.operator_identity.Input.meta.has_mask)
-        assert(self.operator_identity.Output.meta.has_mask)
-
-        output[:2] = self.operator_identity.Output[:2].wait()
-        output[2:] = self.operator_identity.Output[2:].wait()
-
-        assert((data == output).all())
-        assert(data.mask.shape == output.mask.shape)
-        assert((data.mask == output.mask).all())
-
     @nose.tools.raises(AllowMaskException)
     def test3(self):
         # Generate a random dataset and see if it we get the right masking from the operator.
@@ -352,24 +334,6 @@ class TestOpArrayPiper4(object):
             self.operator_identity.Input.setValue(numpy.zeros_like(data))
         except AssertionError as e:
             raise AllowMaskException(str(e))
-
-        assert(self.operator_identity.Input.meta.has_mask)
-        assert(self.operator_identity.Output.meta.has_mask)
-        output = self.operator_identity.Output[None].wait()
-
-        assert((output == 0).all())
-        assert(data.mask.shape == output.mask.shape)
-        assert((output.mask == False).all())
-
-        # Try setInSlot
-        data_shape_roi = roiFromShape(data.shape)
-        data_shape_slice = roiToSlice(*data_shape_roi)
-        self.operator_identity.Input[data_shape_slice] = data
-        output = self.operator_identity.Output[None].wait()
-
-        assert((data == output).all())
-        assert(data.mask.shape == output.mask.shape)
-        assert((data.mask == output.mask).all())
 
     def tearDown(self):
         # Take down operators
@@ -404,14 +368,6 @@ class TestOpArrayPiper5(object):
         except AssertionError as e:
             raise AllowMaskException(str(e))
 
-        assert(self.operator_identity.Input.meta.has_mask)
-        assert(self.operator_identity.Output.meta.has_mask)
-        output = self.operator_identity.Output[None].wait()
-
-        assert((data == output).all())
-        assert(data.mask.shape == output.mask.shape)
-        assert((data.mask == output.mask).all())
-
     @nose.tools.raises(AllowMaskException)
     def test2(self):
         # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
@@ -433,16 +389,6 @@ class TestOpArrayPiper5(object):
         except AssertionError as e:
             raise AllowMaskException(str(e))
 
-        assert(self.operator_identity.Input.meta.has_mask)
-        assert(self.operator_identity.Output.meta.has_mask)
-
-        output[:2] = self.operator_identity.Output[:2].wait()
-        output[2:] = self.operator_identity.Output[2:].wait()
-
-        assert((data == output).all())
-        assert(data.mask.shape == output.mask.shape)
-        assert((data.mask == output.mask).all())
-
     @nose.tools.raises(AllowMaskException)
     def test3(self):
         # Generate a random dataset and see if it we get the right masking from the operator.
@@ -458,24 +404,6 @@ class TestOpArrayPiper5(object):
             self.operator_identity.Input.setValue(numpy.zeros_like(data))
         except AssertionError as e:
             raise AllowMaskException(str(e))
-
-        assert(self.operator_identity.Input.meta.has_mask)
-        assert(self.operator_identity.Output.meta.has_mask)
-        output = self.operator_identity.Output[None].wait()
-
-        assert((output == 0).all())
-        assert(data.mask.shape == output.mask.shape)
-        assert((output.mask == False).all())
-
-        # Try setInSlot
-        data_shape_roi = roiFromShape(data.shape)
-        data_shape_slice = roiToSlice(*data_shape_roi)
-        self.operator_identity.Input[data_shape_slice] = data
-        output = self.operator_identity.Output[None].wait()
-
-        assert((data == output).all())
-        assert(data.mask.shape == output.mask.shape)
-        assert((data.mask == output.mask).all())
 
     def tearDown(self):
         # Take down operators

--- a/tests/testOpArrayPiper.py
+++ b/tests/testOpArrayPiper.py
@@ -25,6 +25,8 @@ __date__ = "$Feb 06, 2015 12:28:04 EST$"
 
 
 
+import nose
+
 import numpy
 
 import vigra
@@ -33,6 +35,10 @@ from lazyflow.graph import Graph
 from lazyflow.operators.opArrayPiper import OpArrayPiper
 from lazyflow.roi import roiFromShape, roiToSlice
 
+
+
+class AllowMaskException(Exception):
+    pass
 
 
 class TestOpArrayPiper(object):
@@ -239,6 +245,114 @@ class TestOpArrayPiper3(object):
 
         # Provide input read all output.
         self.operator_identity.Input.setValue(numpy.zeros_like(data))
+        assert(self.operator_identity.Input.meta.has_mask)
+        assert(self.operator_identity.Output.meta.has_mask)
+        output = self.operator_identity.Output[None].wait()
+
+        assert((output == 0).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((output.mask == False).all())
+
+        # Try setInSlot
+        data_shape_roi = roiFromShape(data.shape)
+        data_shape_slice = roiToSlice(*data_shape_roi)
+        self.operator_identity.Input[data_shape_slice] = data
+        output = self.operator_identity.Output[None].wait()
+
+        assert((data == output).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((data.mask == output.mask).all())
+
+    def tearDown(self):
+        # Take down operators
+        self.operator_identity.Input.disconnect()
+        self.operator_identity.Output.disconnect()
+        self.operator_identity.cleanUp()
+
+
+class TestOpArrayPiper4(object):
+    def setUp(self):
+        self.graph = Graph()
+
+        self.operator_identity = OpArrayPiper(graph=self.graph)
+        self.operator_identity.Input.allow_mask = False
+        self.operator_identity.Output.allow_mask = False
+        self.operator_identity.Input.meta.has_mask = False
+        self.operator_identity.Output.meta.has_mask = False
+
+        self.operator_identity.Input.meta.axistags = vigra.AxisTags("txyzc")
+
+    @nose.tools.raises(AllowMaskException)
+    def test1(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Provide input read all output.
+        try:
+            self.operator_identity.Input.setValue(data)
+        except AssertionError as e:
+            raise AllowMaskException(str(e))
+
+        assert(self.operator_identity.Input.meta.has_mask)
+        assert(self.operator_identity.Output.meta.has_mask)
+        output = self.operator_identity.Output[None].wait()
+
+        assert((data == output).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((data.mask == output.mask).all())
+
+    @nose.tools.raises(AllowMaskException)
+    def test2(self):
+        # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Create array to store results. Don't keep original data.
+        output = data.copy()
+        output[:] = 0
+        output[:] = numpy.ma.nomask
+
+        # Provide input and grab chunks.
+        try:
+            self.operator_identity.Input.setValue(data)
+        except AssertionError as e:
+            raise AllowMaskException(str(e))
+
+        assert(self.operator_identity.Input.meta.has_mask)
+        assert(self.operator_identity.Output.meta.has_mask)
+
+        output[:2] = self.operator_identity.Output[:2].wait()
+        output[2:] = self.operator_identity.Output[2:].wait()
+
+        assert((data == output).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((data.mask == output.mask).all())
+
+    @nose.tools.raises(AllowMaskException)
+    def test3(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Provide input read all output.
+        try:
+            self.operator_identity.Input.setValue(numpy.zeros_like(data))
+        except AssertionError as e:
+            raise AllowMaskException(str(e))
+
         assert(self.operator_identity.Input.meta.has_mask)
         assert(self.operator_identity.Output.meta.has_mask)
         output = self.operator_identity.Output[None].wait()

--- a/tests/testOpArrayPiper.py
+++ b/tests/testOpArrayPiper.py
@@ -87,10 +87,11 @@ class TestOpArrayPiper2(object):
     def test1(self):
         # Generate a random dataset and see if it we get the right masking from the operator.
         data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
-        expected_output = numpy.ma.masked_array(data,
-                                                mask=numpy.zeros(data.shape, dtype=bool),
-                                                shrink=False
-                          )
+        expected_output = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
 
         # Provide input read all output.
         self.operator_identity.Input.setValue(data)
@@ -103,10 +104,11 @@ class TestOpArrayPiper2(object):
     def test2(self):
         # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
         data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
-        expected_output = numpy.ma.masked_array(data,
-                                                mask=numpy.zeros(data.shape, dtype=bool),
-                                                shrink=False
-                          )
+        expected_output = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
 
         # Create array to store results. Don't keep original data.
         output = expected_output.copy()
@@ -140,10 +142,11 @@ class TestOpArrayPiper3(object):
     def test1(self):
         # Generate a random dataset and see if it we get the right masking from the operator.
         data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
-        expected_output = numpy.ma.masked_array(data,
-                                                mask=numpy.zeros(data.shape, dtype=bool),
-                                                shrink=False
-                          )
+        expected_output = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
 
         # Provide input read all output.
         self.operator_identity.Input.setValue(data)
@@ -158,10 +161,11 @@ class TestOpArrayPiper3(object):
     def test2(self):
         # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
         data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
-        expected_output = numpy.ma.masked_array(data,
-                                                mask=numpy.zeros(data.shape, dtype=bool),
-                                                shrink=False
-                          )
+        expected_output = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
 
         # Create array to store results. Don't keep original data.
         output = expected_output.copy()

--- a/tests/testOpArrayPiper.py
+++ b/tests/testOpArrayPiper.py
@@ -418,8 +418,6 @@ class TestOpArrayPiper6(object):
 
         self.operator_identity_1 = OpArrayPiper(graph=self.graph)
         self.operator_identity_2 = OpArrayPiper(graph=self.graph)
-        self.operator_identity_1.Input.allow_mask = True
-        self.operator_identity_1.Output.allow_mask = True
         self.operator_identity_2.Input.allow_mask = False
         self.operator_identity_2.Output.allow_mask = False
 

--- a/tests/testOpArrayPiper.py
+++ b/tests/testOpArrayPiper.py
@@ -34,6 +34,7 @@ from lazyflow.operators.opArrayPiper import OpArrayPiper
 from lazyflow.roi import roiFromShape, roiToSlice
 
 
+
 class TestOpArrayPiper(object):
     def setUp(self):
         self.graph = Graph()

--- a/tests/testOpArrayPiper.py
+++ b/tests/testOpArrayPiper.py
@@ -44,21 +44,19 @@ class TestOpArrayPiper(object):
     def test1(self):
         # Generate a random dataset and see if it we get the right masking from the operator.
         data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
-        expected_output = data.copy()
 
         # Provide input read all output.
         self.operator_identity.Input.setValue(data)
         output = self.operator_identity.Output[None].wait()
 
-        assert((expected_output == output).all())
+        assert((data == output).all())
 
     def test2(self):
         # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
         data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
-        expected_output = data.copy()
 
         # Create array to store results. Don't keep original data.
-        output = expected_output.copy()
+        output = data.copy()
         output[:] = 0
 
         # Provide input and grab chunks.
@@ -66,7 +64,7 @@ class TestOpArrayPiper(object):
         output[:2] = self.operator_identity.Output[:2].wait()
         output[2:] = self.operator_identity.Output[2:].wait()
 
-        assert((expected_output == output).all())
+        assert((data == output).all())
 
     def tearDown(self):
         # Take down operators
@@ -87,7 +85,7 @@ class TestOpArrayPiper2(object):
     def test1(self):
         # Generate a random dataset and see if it we get the right masking from the operator.
         data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
-        expected_output = numpy.ma.masked_array(
+        data = numpy.ma.masked_array(
             data,
             mask=numpy.zeros(data.shape, dtype=bool),
             shrink=False
@@ -97,21 +95,21 @@ class TestOpArrayPiper2(object):
         self.operator_identity.Input.setValue(data)
         output = self.operator_identity.Output[None].wait()
 
-        assert((expected_output == output).all())
-        assert(expected_output.mask.shape == output.mask.shape)
-        assert((expected_output.mask == output.mask).all())
+        assert((data == output).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((data.mask == output.mask).all())
 
     def test2(self):
         # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
         data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
-        expected_output = numpy.ma.masked_array(
+        data = numpy.ma.masked_array(
             data,
             mask=numpy.zeros(data.shape, dtype=bool),
             shrink=False
         )
 
         # Create array to store results. Don't keep original data.
-        output = expected_output.copy()
+        output = data.copy()
         output[:] = 0
         output[:] = numpy.ma.nomask
 
@@ -120,9 +118,9 @@ class TestOpArrayPiper2(object):
         output[:2] = self.operator_identity.Output[:2].wait()
         output[2:] = self.operator_identity.Output[2:].wait()
 
-        assert((expected_output == output).all())
-        assert(expected_output.mask.shape == output.mask.shape)
-        assert((expected_output.mask == output.mask).all())
+        assert((data == output).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((data.mask == output.mask).all())
 
     def tearDown(self):
         # Take down operators
@@ -142,7 +140,7 @@ class TestOpArrayPiper3(object):
     def test1(self):
         # Generate a random dataset and see if it we get the right masking from the operator.
         data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
-        expected_output = numpy.ma.masked_array(
+        data = numpy.ma.masked_array(
             data,
             mask=numpy.zeros(data.shape, dtype=bool),
             shrink=False
@@ -154,21 +152,21 @@ class TestOpArrayPiper3(object):
         assert(self.operator_identity.Output.meta.has_mask)
         output = self.operator_identity.Output[None].wait()
 
-        assert((expected_output == output).all())
-        assert(expected_output.mask.shape == output.mask.shape)
-        assert((expected_output.mask == output.mask).all())
+        assert((data == output).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((data.mask == output.mask).all())
 
     def test2(self):
         # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
         data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
-        expected_output = numpy.ma.masked_array(
+        data = numpy.ma.masked_array(
             data,
             mask=numpy.zeros(data.shape, dtype=bool),
             shrink=False
         )
 
         # Create array to store results. Don't keep original data.
-        output = expected_output.copy()
+        output = data.copy()
         output[:] = 0
         output[:] = numpy.ma.nomask
 
@@ -179,9 +177,9 @@ class TestOpArrayPiper3(object):
         output[:2] = self.operator_identity.Output[:2].wait()
         output[2:] = self.operator_identity.Output[2:].wait()
 
-        assert((expected_output == output).all())
-        assert(expected_output.mask.shape == output.mask.shape)
-        assert((expected_output.mask == output.mask).all())
+        assert((data == output).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((data.mask == output.mask).all())
 
     def tearDown(self):
         # Take down operators

--- a/tests/testOpArrayPiperWithAccessCount.py
+++ b/tests/testOpArrayPiperWithAccessCount.py
@@ -25,3 +25,482 @@ __date__ = "$Mar 06, 2015 12:14:39 EST$"
 
 
 
+import nose
+
+import numpy
+
+import vigra
+
+from lazyflow.graph import Graph
+from lazyflow.utility.testing import OpArrayPiperWithAccessCount
+from lazyflow.roi import roiFromShape, roiToSlice
+
+
+
+class AllowMaskException(Exception):
+    pass
+
+
+class TestOpArrayPiperWithAccessCount(object):
+    def setUp(self):
+        self.graph = Graph()
+
+        self.operator_identity = OpArrayPiperWithAccessCount(graph=self.graph)
+
+        self.operator_identity.Input.meta.axistags = vigra.AxisTags("txyzc")
+
+    def test1(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+
+        # Provide input read all output.
+        self.operator_identity.Input.setValue(data)
+        output = self.operator_identity.Output[None].wait()
+
+        assert (self.operator_identity.accessCount == 1)
+        assert((data == output).all())
+
+    def test2(self):
+        # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+
+        # Create array to store results. Don't keep original data.
+        output = data.copy()
+        output[:] = 0
+
+        # Provide input and grab chunks.
+        self.operator_identity.Input.setValue(data)
+        output[:2] = self.operator_identity.Output[:2].wait()
+        output[2:] = self.operator_identity.Output[2:].wait()
+
+        assert (self.operator_identity.accessCount == 2)
+        assert((data == output).all())
+
+    def test3(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+
+        # Provide input read all output.
+        self.operator_identity.Input.setValue(numpy.zeros_like(data))
+        output = self.operator_identity.Output[None].wait()
+
+        assert (self.operator_identity.accessCount == 1)
+        assert((output == 0).all())
+
+    def tearDown(self):
+        # Take down operators
+        self.operator_identity.Input.disconnect()
+        self.operator_identity.Output.disconnect()
+        self.operator_identity.cleanUp()
+
+
+class TestOpArrayPiperWithAccessCount2(object):
+    def setUp(self):
+        self.graph = Graph()
+
+        self.operator_identity = OpArrayPiperWithAccessCount(graph=self.graph)
+
+        self.operator_identity.Input.meta.axistags = vigra.AxisTags("txyzc")
+        self.operator_identity.Input.meta.has_mask = True
+
+    def test1(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Provide input read all output.
+        self.operator_identity.Input.setValue(data)
+        output = self.operator_identity.Output[None].wait()
+
+        assert (self.operator_identity.accessCount == 1)
+        assert((data == output).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((data.mask == output.mask).all())
+
+    def test2(self):
+        # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Create array to store results. Don't keep original data.
+        output = data.copy()
+        output[:] = 0
+        output[:] = numpy.ma.nomask
+
+        # Provide input and grab chunks.
+        self.operator_identity.Input.setValue(data)
+        output[:2] = self.operator_identity.Output[:2].wait()
+        output[2:] = self.operator_identity.Output[2:].wait()
+
+        assert (self.operator_identity.accessCount == 2)
+        assert((data == output).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((data.mask == output.mask).all())
+
+    def test3(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Provide input read all output.
+        self.operator_identity.Input.setValue(numpy.zeros_like(data))
+        output = self.operator_identity.Output[None].wait()
+
+        assert (self.operator_identity.accessCount == 1)
+        assert((output == 0).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((output.mask == False).all())
+
+    def tearDown(self):
+        # Take down operators
+        self.operator_identity.Input.disconnect()
+        self.operator_identity.Output.disconnect()
+        self.operator_identity.cleanUp()
+
+
+class TestOpArrayPiperWithAccessCount3(object):
+    def setUp(self):
+        self.graph = Graph()
+
+        self.operator_identity = OpArrayPiperWithAccessCount(graph=self.graph)
+
+        self.operator_identity.Input.meta.axistags = vigra.AxisTags("txyzc")
+
+    def test1(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Provide input read all output.
+        self.operator_identity.Input.setValue(data)
+        assert(self.operator_identity.Input.meta.has_mask)
+        assert(self.operator_identity.Output.meta.has_mask)
+        output = self.operator_identity.Output[None].wait()
+
+        assert (self.operator_identity.accessCount == 1)
+        assert((data == output).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((data.mask == output.mask).all())
+
+    def test2(self):
+        # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Create array to store results. Don't keep original data.
+        output = data.copy()
+        output[:] = 0
+        output[:] = numpy.ma.nomask
+
+        # Provide input and grab chunks.
+        self.operator_identity.Input.setValue(data)
+        assert(self.operator_identity.Input.meta.has_mask)
+        assert(self.operator_identity.Output.meta.has_mask)
+        output[:2] = self.operator_identity.Output[:2].wait()
+        output[2:] = self.operator_identity.Output[2:].wait()
+
+        assert (self.operator_identity.accessCount == 2)
+        assert((data == output).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((data.mask == output.mask).all())
+
+    def test3(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Provide input read all output.
+        self.operator_identity.Input.setValue(numpy.zeros_like(data))
+        assert(self.operator_identity.Input.meta.has_mask)
+        assert(self.operator_identity.Output.meta.has_mask)
+        output = self.operator_identity.Output[None].wait()
+
+        assert (self.operator_identity.accessCount == 1)
+        assert((output == 0).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((output.mask == False).all())
+
+    def tearDown(self):
+        # Take down operators
+        self.operator_identity.Input.disconnect()
+        self.operator_identity.Output.disconnect()
+        self.operator_identity.cleanUp()
+
+
+class TestOpArrayPiperWithAccessCount4(object):
+    def setUp(self):
+        self.graph = Graph()
+
+        self.operator_identity = OpArrayPiperWithAccessCount(graph=self.graph)
+        self.operator_identity.Input.allow_mask = False
+        self.operator_identity.Output.allow_mask = False
+        self.operator_identity.Input.meta.has_mask = False
+        self.operator_identity.Output.meta.has_mask = False
+
+        self.operator_identity.Input.meta.axistags = vigra.AxisTags("txyzc")
+
+    @nose.tools.raises(AllowMaskException)
+    def test1(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Provide input read all output.
+        try:
+            self.operator_identity.Input.setValue(data)
+        except AssertionError as e:
+            raise AllowMaskException(str(e))
+
+    @nose.tools.raises(AllowMaskException)
+    def test2(self):
+        # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Create array to store results. Don't keep original data.
+        output = data.copy()
+        output[:] = 0
+        output[:] = numpy.ma.nomask
+
+        # Provide input and grab chunks.
+        try:
+            self.operator_identity.Input.setValue(data)
+        except AssertionError as e:
+            raise AllowMaskException(str(e))
+
+    @nose.tools.raises(AllowMaskException)
+    def test3(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Provide input read all output.
+        try:
+            self.operator_identity.Input.setValue(numpy.zeros_like(data))
+        except AssertionError as e:
+            raise AllowMaskException(str(e))
+
+    def tearDown(self):
+        # Take down operators
+        self.operator_identity.Input.disconnect()
+        self.operator_identity.Output.disconnect()
+        self.operator_identity.cleanUp()
+
+
+class TestOpArrayPiperWithAccessCount5(object):
+    def setUp(self):
+        self.graph = Graph()
+
+        self.operator_identity = OpArrayPiperWithAccessCount(graph=self.graph)
+        self.operator_identity.Input.allow_mask = False
+        self.operator_identity.Output.allow_mask = False
+
+        self.operator_identity.Input.meta.axistags = vigra.AxisTags("txyzc")
+
+    @nose.tools.raises(AllowMaskException)
+    def test1(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Provide input read all output.
+        try:
+            self.operator_identity.Input.setValue(data)
+        except AssertionError as e:
+            raise AllowMaskException(str(e))
+
+    @nose.tools.raises(AllowMaskException)
+    def test2(self):
+        # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Provide input and grab chunks.
+        try:
+            self.operator_identity.Input.setValue(data)
+        except AssertionError as e:
+            raise AllowMaskException(str(e))
+
+    @nose.tools.raises(AllowMaskException)
+    def test3(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Provide input read all output.
+        try:
+            self.operator_identity.Input.setValue(numpy.zeros_like(data))
+        except AssertionError as e:
+            raise AllowMaskException(str(e))
+
+    def tearDown(self):
+        # Take down operators
+        self.operator_identity.Input.disconnect()
+        self.operator_identity.Output.disconnect()
+        self.operator_identity.cleanUp()
+
+
+class TestOpArrayPiperWithAccessCount6(object):
+    def setUp(self):
+        self.graph = Graph()
+
+        self.operator_identity_1 = OpArrayPiperWithAccessCount(graph=self.graph)
+        self.operator_identity_2 = OpArrayPiperWithAccessCount(graph=self.graph)
+        self.operator_identity_2.Input.allow_mask = False
+        self.operator_identity_2.Output.allow_mask = False
+
+        self.operator_identity_1.Input.meta.axistags = vigra.AxisTags("txyzc")
+        self.operator_identity_2.Input.meta.axistags = vigra.AxisTags("txyzc")
+
+    @nose.tools.raises(AllowMaskException)
+    def test1(self):
+        # Explicitly set has_mask for the input
+        self.operator_identity_1.Input.meta.has_mask = True
+        self.operator_identity_1.Output.meta.has_mask = True
+
+        # Try to connect the incompatible operators.
+        try:
+            self.operator_identity_2.Input.connect(self.operator_identity_1.Output)
+        except AssertionError as e:
+            raise AllowMaskException(str(e))
+
+    @nose.tools.raises(AllowMaskException)
+    def test2(self):
+        # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Implicitly set has_mask for the input by setting the value.
+        self.operator_identity_1.Input.setValue(data)
+
+        # Try to connect the incompatible operators.
+        try:
+            self.operator_identity_2.Input.connect(self.operator_identity_1.Output)
+        except AssertionError as e:
+            raise AllowMaskException(str(e))
+
+    def tearDown(self):
+        # Take down operators
+        self.operator_identity_2.Input.disconnect()
+        self.operator_identity_2.Output.disconnect()
+        self.operator_identity_2.cleanUp()
+        self.operator_identity_1.Input.disconnect()
+        self.operator_identity_1.Output.disconnect()
+        self.operator_identity_1.cleanUp()
+
+
+class TestOpArrayPiperWithAccessCount7(object):
+    def setUp(self):
+        self.graph = Graph()
+
+        self.operator_identity_1 = OpArrayPiperWithAccessCount(graph=self.graph)
+        self.operator_identity_2 = OpArrayPiperWithAccessCount(graph=self.graph)
+
+        self.operator_identity_1.Input.meta.axistags = vigra.AxisTags("txyzc")
+        self.operator_identity_2.Input.meta.axistags = vigra.AxisTags("txyzc")
+
+    def test1(self):
+        # Explicitly set has_mask for the input
+        self.operator_identity_1.Input.meta.has_mask = True
+        self.operator_identity_1.Output.meta.has_mask = True
+
+        # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Try to connect the compatible operators.
+        self.operator_identity_2.Input.connect(self.operator_identity_1.Output)
+        self.operator_identity_1.Input.setValue(data)
+        output = self.operator_identity_2.Output[None].wait()
+
+        assert (self.operator_identity_1.accessCount == 1)
+        assert (self.operator_identity_2.accessCount == 1)
+        assert((data == output).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((data.mask == output.mask).all())
+
+
+    def test2(self):
+        # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        data = numpy.ma.masked_array(
+            data,
+            mask=numpy.zeros(data.shape, dtype=bool),
+            shrink=False
+        )
+
+        # Try to connect the compatible operators.
+        self.operator_identity_1.Input.setValue(data)
+        self.operator_identity_2.Input.connect(self.operator_identity_1.Output)
+        output = self.operator_identity_2.Output[None].wait()
+
+        assert (self.operator_identity_1.accessCount == 1)
+        assert (self.operator_identity_2.accessCount == 1)
+        assert((data == output).all())
+        assert(data.mask.shape == output.mask.shape)
+        assert((data.mask == output.mask).all())
+
+    def tearDown(self):
+        # Take down operators
+        self.operator_identity_2.Input.disconnect()
+        self.operator_identity_2.Output.disconnect()
+        self.operator_identity_2.cleanUp()
+        self.operator_identity_1.Input.disconnect()
+        self.operator_identity_1.Output.disconnect()
+        self.operator_identity_1.cleanUp()

--- a/tests/testOpArrayPiperWithAccessCount.py
+++ b/tests/testOpArrayPiperWithAccessCount.py
@@ -1,0 +1,27 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#		   http://ilastik.org/license/
+###############################################################################
+
+__author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
+__date__ = "$Mar 06, 2015 12:14:39 EST$"
+
+
+

--- a/tests/testOpBlockedArrayCache.py
+++ b/tests/testOpBlockedArrayCache.py
@@ -458,7 +458,7 @@ class TestOpBlockedArrayCache_masked(object):
         # but fixAtCurrent is True so the cache gives us zeros
         assert (data == 0).all()
         assert (data.mask == False).all()
-        assert (data.fill_value == numpy.iinfo(numpy.int_).max).all()
+        assert (data.fill_value == 0).all()
 
         opCache.fixAtCurrent.setValue(False)
 

--- a/tests/testOpCompressedUserLabelArray.py
+++ b/tests/testOpCompressedUserLabelArray.py
@@ -326,16 +326,16 @@ class TestOpCompressedUserLabelArray_masked(object):
         op.Input.meta.axistags = vigra.defaultAxistags('txyzc')
         op.Input.meta.has_mask = True
         dummyData = numpy.zeros(arrayshape, dtype=numpy.uint8)
-        dummyData = numpy.ma.masked_array(dummyData, mask=numpy.ma.getmaskarray(dummyData), fill_value=numpy.uint8(255), shrink=False)
+        dummyData = numpy.ma.masked_array(dummyData, mask=numpy.ma.getmaskarray(dummyData), fill_value=numpy.uint8(0), shrink=False)
         op.Input.setValue( dummyData )
 
         slicing = sl[0:1, 1:15, 2:36, 3:7, 0:1]
         inDataShape = slicing2shape(slicing)
         inputData = ( 3*numpy.random.random(inDataShape) ).astype(numpy.uint8)
-        inputData = numpy.ma.masked_array(inputData, mask=numpy.ma.getmaskarray(inputData), fill_value=numpy.uint8(255), shrink=False)
+        inputData = numpy.ma.masked_array(inputData, mask=numpy.ma.getmaskarray(inputData), fill_value=numpy.uint8(0), shrink=False)
         inputData[:, 0] = numpy.ma.masked
         op.Input[slicing] = inputData
-        data = numpy.ma.zeros(arrayshape, dtype=numpy.uint8, fill_value=numpy.uint8(255))
+        data = numpy.ma.zeros(arrayshape, dtype=numpy.uint8, fill_value=numpy.uint8(0))
         data[slicing] = inputData
 
         self.op = op

--- a/tests/testOpFillMaskArray.py
+++ b/tests/testOpFillMaskArray.py
@@ -69,7 +69,7 @@ class TestOpFillMaskArray(object):
         self.operator_fill.InputFillValue.setValue(numpy.nan)
         output = self.operator_fill.Output[None].wait()
 
-        assert not isinstance(expected_output, numpy.ma.masked_array)
+        assert not isinstance(output, numpy.ma.masked_array)
         assert (
             (expected_output == output) |
             (numpy.isnan(expected_output) & numpy.isnan(output))
@@ -108,7 +108,7 @@ class TestOpFillMaskArray(object):
         output[:2] = self.operator_fill.Output[:2].wait()
         output[2:] = self.operator_fill.Output[2:].wait()
 
-        assert not isinstance(expected_output, numpy.ma.masked_array)
+        assert not isinstance(output, numpy.ma.masked_array)
         assert (
             (expected_output == output) |
             (numpy.isnan(expected_output) & numpy.isnan(output))
@@ -159,7 +159,7 @@ class TestOpFillMaskArray2(object):
         self.operator_fill.InputFillValue.setValue(numpy.nan)
         output = self.operator_identity.Output[None].wait()
 
-        assert not isinstance(expected_output, numpy.ma.masked_array)
+        assert not isinstance(output, numpy.ma.masked_array)
         assert (
             (expected_output == output) |
             (numpy.isnan(expected_output) & numpy.isnan(output))
@@ -197,7 +197,7 @@ class TestOpFillMaskArray2(object):
         output[:2] = self.operator_identity.Output[:2].wait()
         output[2:] = self.operator_identity.Output[2:].wait()
 
-        assert not isinstance(expected_output, numpy.ma.masked_array)
+        assert not isinstance(output, numpy.ma.masked_array)
         assert (
             (expected_output == output) |
             (numpy.isnan(expected_output) & numpy.isnan(output))

--- a/tests/testOpFillMaskArray.py
+++ b/tests/testOpFillMaskArray.py
@@ -101,7 +101,6 @@ class TestOpFillMaskArray(object):
         # Create array to store results. Don't keep original data.
         output = expected_output.copy()
         output[:] = 0
-        output[:] = numpy.ma.nomask
 
         # Provide input and grab chunks.
         self.operator_fill.InputArray.setValue(data)
@@ -191,7 +190,6 @@ class TestOpFillMaskArray2(object):
         # Create array to store results. Don't keep original data.
         output = expected_output.copy()
         output[:] = 0
-        output[:] = numpy.ma.nomask
 
         # Provide input and grab chunks.
         self.operator_fill.InputArray.setValue(data)

--- a/tests/testOpFillMaskArray.py
+++ b/tests/testOpFillMaskArray.py
@@ -59,6 +59,7 @@ class TestOpFillMaskArray(object):
         data = numpy.ma.masked_array(
             data,
             mask=mask,
+            fill_value=data.dtype.type(numpy.nan),
             shrink=False
         )
 
@@ -93,6 +94,7 @@ class TestOpFillMaskArray(object):
         data = numpy.ma.masked_array(
             data,
             mask=mask,
+            fill_value=data.dtype.type(numpy.nan),
             shrink=False
         )
 
@@ -105,6 +107,79 @@ class TestOpFillMaskArray(object):
         # Provide input and grab chunks.
         self.operator_fill.InputArray.setValue(data)
         self.operator_fill.InputFillValue.setValue(numpy.nan)
+        output[:2] = self.operator_fill.Output[:2].wait()
+        output[2:] = self.operator_fill.Output[2:].wait()
+
+        assert not isinstance(output, numpy.ma.masked_array)
+        assert (
+            (expected_output == output) |
+            (numpy.isnan(expected_output) & numpy.isnan(output))
+        ).all()
+
+    def test3(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        mask = numpy.zeros(data.shape, dtype=bool)
+
+        # Mask borders of the expected output.
+        left_slicing = (mask.ndim - 1) * (slice(None),) + (slice(None, 1),)
+        right_slicing = (mask.ndim - 1) * (slice(None),) + (slice(-1, None),)
+        for i in xrange(mask.ndim):
+            left_slicing = left_slicing[-1:] + left_slicing[:-1]
+            right_slicing = right_slicing[-1:] + right_slicing[:-1]
+
+            mask[left_slicing] = True
+            mask[right_slicing] = True
+
+        data = numpy.ma.masked_array(
+            data,
+            mask=mask,
+            fill_value=data.dtype.type(numpy.nan),
+            shrink=False
+        )
+
+        expected_output = data.filled(numpy.nan)
+
+        # Provide input read all output.
+        self.operator_fill.InputArray.setValue(data)
+        output = self.operator_fill.Output[None].wait()
+
+        assert not isinstance(output, numpy.ma.masked_array)
+        assert (
+            (expected_output == output) |
+            (numpy.isnan(expected_output) & numpy.isnan(output))
+        ).all()
+
+    def test4(self):
+        # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        mask = numpy.zeros(data.shape, dtype=bool)
+
+        # Mask borders of the expected output.
+        left_slicing = (mask.ndim - 1) * (slice(None),) + (slice(None, 1),)
+        right_slicing = (mask.ndim - 1) * (slice(None),) + (slice(-1, None),)
+        for i in xrange(mask.ndim):
+            left_slicing = left_slicing[-1:] + left_slicing[:-1]
+            right_slicing = right_slicing[-1:] + right_slicing[:-1]
+
+            mask[left_slicing] = True
+            mask[right_slicing] = True
+
+        data = numpy.ma.masked_array(
+            data,
+            mask=mask,
+            fill_value=data.dtype.type(numpy.nan),
+            shrink=False
+        )
+
+        expected_output = data.filled(numpy.nan)
+
+        # Create array to store results. Don't keep original data.
+        output = expected_output.copy()
+        output[:] = 0
+
+        # Provide input and grab chunks.
+        self.operator_fill.InputArray.setValue(data)
         output[:2] = self.operator_fill.Output[:2].wait()
         output[2:] = self.operator_fill.Output[2:].wait()
 
@@ -149,6 +224,7 @@ class TestOpFillMaskArray2(object):
 
         data = numpy.ma.masked_array(data,
                                      mask=mask,
+                                     fill_value=data.dtype.type(numpy.nan),
                                      shrink=False
         )
 
@@ -182,6 +258,7 @@ class TestOpFillMaskArray2(object):
 
         data = numpy.ma.masked_array(data,
                                      mask=mask,
+                                     fill_value=data.dtype.type(numpy.nan),
                                      shrink=False
         )
 
@@ -194,6 +271,77 @@ class TestOpFillMaskArray2(object):
         # Provide input and grab chunks.
         self.operator_fill.InputArray.setValue(data)
         self.operator_fill.InputFillValue.setValue(numpy.nan)
+        output[:2] = self.operator_identity.Output[:2].wait()
+        output[2:] = self.operator_identity.Output[2:].wait()
+
+        assert not isinstance(output, numpy.ma.masked_array)
+        assert (
+            (expected_output == output) |
+            (numpy.isnan(expected_output) & numpy.isnan(output))
+        ).all()
+
+    def test3(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        mask = numpy.zeros(data.shape, dtype=bool)
+
+        # Mask borders of the expected output.
+        left_slicing = (mask.ndim - 1) * (slice(None),) + (slice(None, 1),)
+        right_slicing = (mask.ndim - 1) * (slice(None),) + (slice(-1, None),)
+        for i in xrange(mask.ndim):
+            left_slicing = left_slicing[-1:] + left_slicing[:-1]
+            right_slicing = right_slicing[-1:] + right_slicing[:-1]
+
+            mask[left_slicing] = True
+            mask[right_slicing] = True
+
+        data = numpy.ma.masked_array(data,
+                                     mask=mask,
+                                     fill_value=data.dtype.type(numpy.nan),
+                                     shrink=False
+        )
+
+        expected_output = data.filled(numpy.nan)
+
+        # Provide input read all output.
+        self.operator_fill.InputArray.setValue(data)
+        output = self.operator_identity.Output[None].wait()
+
+        assert not isinstance(output, numpy.ma.masked_array)
+        assert (
+            (expected_output == output) |
+            (numpy.isnan(expected_output) & numpy.isnan(output))
+        ).all()
+
+    def test4(self):
+        # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        mask = numpy.zeros(data.shape, dtype=bool)
+
+        # Mask borders of the expected output.
+        left_slicing = (mask.ndim - 1) * (slice(None),) + (slice(None, 1),)
+        right_slicing = (mask.ndim - 1) * (slice(None),) + (slice(-1, None),)
+        for i in xrange(mask.ndim):
+            left_slicing = left_slicing[-1:] + left_slicing[:-1]
+            right_slicing = right_slicing[-1:] + right_slicing[:-1]
+
+            mask[left_slicing] = True
+            mask[right_slicing] = True
+
+        data = numpy.ma.masked_array(data,
+                                     mask=mask,
+                                     fill_value=data.dtype.type(numpy.nan),
+                                     shrink=False
+        )
+
+        expected_output = data.filled(numpy.nan)
+
+        # Create array to store results. Don't keep original data.
+        output = expected_output.copy()
+        output[:] = 0
+
+        # Provide input and grab chunks.
+        self.operator_fill.InputArray.setValue(data)
         output[:2] = self.operator_identity.Output[:2].wait()
         output[2:] = self.operator_identity.Output[2:].wait()
 

--- a/tests/testOpFillMaskArray.py
+++ b/tests/testOpFillMaskArray.py
@@ -356,6 +356,10 @@ class TestOpFillMaskArray2(object):
         self.operator_identity.Input.disconnect()
         self.operator_identity.Output.disconnect()
         self.operator_identity.cleanUp()
+        self.operator_fill.InputArray.disconnect()
+        self.operator_fill.InputFillValue.disconnect()
+        self.operator_fill.Output.disconnect()
+        self.operator_fill.cleanUp()
 
 
 if __name__ == "__main__":

--- a/tests/testOpFillMaskArray.py
+++ b/tests/testOpFillMaskArray.py
@@ -25,5 +25,197 @@ __date__ = "$Feb 26, 2015 12:02:29 EST$"
 
 
 
+import numpy
+
+import vigra
+
+from lazyflow.graph import Graph
+from lazyflow.operators.opArrayPiper import OpArrayPiper
+from lazyflow.operators.opFillMaskArray import OpFillMaskArray
 
 
+class TestOpFillMaskArray(object):
+    def setUp(self):
+        self.graph = Graph()
+
+        self.operator_fill = OpFillMaskArray(graph=self.graph)
+        self.operator_fill.InputArray.meta.axistags = vigra.AxisTags("txyzc")
+
+    def test1(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        mask = numpy.zeros(data.shape, dtype=bool)
+
+        # Mask borders of the expected output.
+        left_slicing = (mask.ndim - 1) * (slice(None),) + (slice(None, 1),)
+        right_slicing = (mask.ndim - 1) * (slice(None),) + (slice(-1, None),)
+        for i in xrange(mask.ndim):
+            left_slicing = left_slicing[-1:] + left_slicing[:-1]
+            right_slicing = right_slicing[-1:] + right_slicing[:-1]
+
+            mask[left_slicing] = True
+            mask[right_slicing] = True
+
+        data = numpy.ma.masked_array(
+            data,
+            mask=mask,
+            shrink=False
+        )
+
+        expected_output = data.filled(numpy.nan)
+
+        # Provide input read all output.
+        self.operator_fill.InputArray.setValue(data)
+        self.operator_fill.InputFillValue.setValue(numpy.nan)
+        output = self.operator_fill.Output[None].wait()
+
+        assert not isinstance(expected_output, numpy.ma.masked_array)
+        assert (
+            (expected_output == output) |
+            (numpy.isnan(expected_output) & numpy.isnan(output))
+        ).all()
+
+    def test2(self):
+        # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        mask = numpy.zeros(data.shape, dtype=bool)
+
+        # Mask borders of the expected output.
+        left_slicing = (mask.ndim - 1) * (slice(None),) + (slice(None, 1),)
+        right_slicing = (mask.ndim - 1) * (slice(None),) + (slice(-1, None),)
+        for i in xrange(mask.ndim):
+            left_slicing = left_slicing[-1:] + left_slicing[:-1]
+            right_slicing = right_slicing[-1:] + right_slicing[:-1]
+
+            mask[left_slicing] = True
+            mask[right_slicing] = True
+
+        data = numpy.ma.masked_array(
+            data,
+            mask=mask,
+            shrink=False
+        )
+
+        expected_output = data.filled(numpy.nan)
+
+        # Create array to store results. Don't keep original data.
+        output = expected_output.copy()
+        output[:] = 0
+        output[:] = numpy.ma.nomask
+
+        # Provide input and grab chunks.
+        self.operator_fill.InputArray.setValue(data)
+        self.operator_fill.InputFillValue.setValue(numpy.nan)
+        output[:2] = self.operator_fill.Output[:2].wait()
+        output[2:] = self.operator_fill.Output[2:].wait()
+
+        assert not isinstance(expected_output, numpy.ma.masked_array)
+        assert (
+            (expected_output == output) |
+            (numpy.isnan(expected_output) & numpy.isnan(output))
+        ).all()
+
+    def tearDown(self):
+        # Take down operators
+        self.operator_fill.InputArray.disconnect()
+        self.operator_fill.Output.disconnect()
+        self.operator_fill.cleanUp()
+
+
+class TestOpFillMaskArray2(object):
+    def setUp(self):
+        self.graph = Graph()
+
+        self.operator_fill = OpFillMaskArray(graph=self.graph)
+        self.operator_identity = OpArrayPiper(graph=self.graph)
+
+        self.operator_fill.InputArray.meta.axistags = vigra.AxisTags("txyzc")
+
+        self.operator_identity.Input.connect(self.operator_fill.Output)
+
+    def test1(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        mask = numpy.zeros(data.shape, dtype=bool)
+
+        # Mask borders of the expected output.
+        left_slicing = (mask.ndim - 1) * (slice(None),) + (slice(None, 1),)
+        right_slicing = (mask.ndim - 1) * (slice(None),) + (slice(-1, None),)
+        for i in xrange(mask.ndim):
+            left_slicing = left_slicing[-1:] + left_slicing[:-1]
+            right_slicing = right_slicing[-1:] + right_slicing[:-1]
+
+            mask[left_slicing] = True
+            mask[right_slicing] = True
+
+        data = numpy.ma.masked_array(data,
+                                     mask=mask,
+                                     shrink=False
+        )
+
+        expected_output = data.filled(numpy.nan)
+
+        # Provide input read all output.
+        self.operator_fill.InputArray.setValue(data)
+        self.operator_fill.InputFillValue.setValue(numpy.nan)
+        output = self.operator_identity.Output[None].wait()
+
+        assert not isinstance(expected_output, numpy.ma.masked_array)
+        assert (
+            (expected_output == output) |
+            (numpy.isnan(expected_output) & numpy.isnan(output))
+        ).all()
+
+    def test2(self):
+        # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        mask = numpy.zeros(data.shape, dtype=bool)
+
+        # Mask borders of the expected output.
+        left_slicing = (mask.ndim - 1) * (slice(None),) + (slice(None, 1),)
+        right_slicing = (mask.ndim - 1) * (slice(None),) + (slice(-1, None),)
+        for i in xrange(mask.ndim):
+            left_slicing = left_slicing[-1:] + left_slicing[:-1]
+            right_slicing = right_slicing[-1:] + right_slicing[:-1]
+
+            mask[left_slicing] = True
+            mask[right_slicing] = True
+
+        data = numpy.ma.masked_array(data,
+                                     mask=mask,
+                                     shrink=False
+        )
+
+        expected_output = data.filled(numpy.nan)
+
+        # Create array to store results. Don't keep original data.
+        output = expected_output.copy()
+        output[:] = 0
+        output[:] = numpy.ma.nomask
+
+        # Provide input and grab chunks.
+        self.operator_fill.InputArray.setValue(data)
+        self.operator_fill.InputFillValue.setValue(numpy.nan)
+        output[:2] = self.operator_identity.Output[:2].wait()
+        output[2:] = self.operator_identity.Output[2:].wait()
+
+        assert not isinstance(expected_output, numpy.ma.masked_array)
+        assert (
+            (expected_output == output) |
+            (numpy.isnan(expected_output) & numpy.isnan(output))
+        ).all()
+
+    def tearDown(self):
+        # Take down operators
+        self.operator_identity.Input.disconnect()
+        self.operator_identity.Output.disconnect()
+        self.operator_identity.cleanUp()
+
+
+if __name__ == "__main__":
+    import sys
+    import nose
+    sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
+    sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
+    ret = nose.run(defaultTest=__file__)
+    if not ret: sys.exit(1)

--- a/tests/testOpFillMaskArray.py
+++ b/tests/testOpFillMaskArray.py
@@ -1,0 +1,29 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#		   http://ilastik.org/license/
+###############################################################################
+
+__author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
+__date__ = "$Feb 26, 2015 12:02:29 EST$"
+
+
+
+
+

--- a/tests/testOpMaskArray.py
+++ b/tests/testOpMaskArray.py
@@ -255,6 +255,10 @@ class TestOpMaskArray3(object):
         self.operator_identity.Input.disconnect()
         self.operator_identity.Output.disconnect()
         self.operator_identity.cleanUp()
+        self.operator_border.InputArray.disconnect()
+        self.operator_border.InputMask.disconnect()
+        self.operator_border.Output.disconnect()
+        self.operator_border.cleanUp()
 
 
 if __name__ == "__main__":

--- a/tests/testOpSlicedBlockedArrayCache.py
+++ b/tests/testOpSlicedBlockedArrayCache.py
@@ -389,7 +389,6 @@ class TestOpSlicedBlockedArrayCache_masked(object):
         slicing = make_key[0:1, 0:10, 10:20, 0:10, 0:1]
         oldAccessCount = opProvider.accessCount
         data = opCache.Output( slicing ).wait()
-        data.axistags = opCache.Output.meta.axistags
         assert (data == self.data[slicing]).all()
         assert (data.mask == self.data.mask[slicing]).all()
         assert (data.fill_value == self.data.fill_value).all()
@@ -409,7 +408,6 @@ class TestOpSlicedBlockedArrayCache_masked(object):
         slicing = make_key[0:1, 45:65, 10:20, 0:10, 0:1]
         data = opCache.Output( slicing ).wait()
 
-        data.axistags = opCache.Output.meta.axistags
         assert (data == self.data[slicing]).all()
         assert (data.mask == self.data.mask[slicing]).all()
         assert (data.fill_value == self.data.fill_value).all()
@@ -435,7 +433,6 @@ class TestOpSlicedBlockedArrayCache_masked(object):
         # Request
         slicing = make_key[:, 0:50, 15:45, 0:10, :]
         data = opCache.Output( slicing ).wait()
-        data.axistags = opCache.Output.meta.axistags
         assert (data == self.data[slicing]).all()
         assert (data.mask == self.data.mask[slicing]).all()
         assert (data.fill_value == self.data.fill_value).all()
@@ -462,7 +459,6 @@ class TestOpSlicedBlockedArrayCache_masked(object):
 
         # Same request, but should need to access the data again due to dirtiness
         data = opCache.Output( slicing ).wait()
-        data.axistags = opCache.Output.meta.axistags
         assert (data == self.data[slicing]).all()
         assert (data.mask == self.data.mask[slicing]).all()
         assert (data.fill_value == self.data.fill_value).all()
@@ -503,7 +499,6 @@ class TestOpSlicedBlockedArrayCache_masked(object):
         # Request again.  Data should match this time.
         oldAccessCount = opProvider.accessCount
         data = opCache.Output( slicing ).wait()
-        data.axistags = opCache.Output.meta.axistags
         assert (data == self.data[slicing]).all()
         assert (data.mask == self.data.mask[slicing]).all()
         assert (data.fill_value == self.data.fill_value).all()
@@ -518,7 +513,6 @@ class TestOpSlicedBlockedArrayCache_masked(object):
 
         # Request again.  Data should match WITHOUT requesting from the source.
         data = opCache.Output( slicing ).wait()
-        data.axistags = opCache.Output.meta.axistags
         assert (data == self.data[slicing]).all()
         assert (data.mask == self.data.mask[slicing]).all()
         assert (data.fill_value == self.data.fill_value).all()
@@ -540,7 +534,6 @@ class TestOpSlicedBlockedArrayCache_masked(object):
 
         # Same request.  Data should still match the previous data (not yet refreshed)
         data2 = opCache.Output( slicing ).wait()
-        data2.axistags = opCache.Output.meta.axistags
         assert opProvider.accessCount == oldAccessCount, "Access count={}, expected={}".format(opProvider.accessCount, oldAccessCount)
         assert (data2 == data).all()
         assert (data2.mask == data.mask).all()
@@ -554,7 +547,6 @@ class TestOpSlicedBlockedArrayCache_masked(object):
 
         # Same request.  Data should be updated now that we're unfrozen.
         data = opCache.Output( slicing ).wait()
-        data.axistags = opCache.Output.meta.axistags
         assert (data == self.data[slicing]).all()
         assert (data.mask == self.data.mask[slicing]).all()
         assert (data.fill_value == self.data.fill_value).all()
@@ -580,7 +572,6 @@ class TestOpSlicedBlockedArrayCache_masked(object):
 
         # Same request.  Data should still match the previous data (not yet refreshed)
         data2 = opCache.Output( slicing ).wait()
-        data2.axistags = opCache.Output.meta.axistags
         assert opProvider.accessCount == oldAccessCount, "Access count={}, expected={}".format(opProvider.accessCount, oldAccessCount)
         assert (data2 == data).all()
         assert (data2.mask == data.mask).all()
@@ -592,7 +583,6 @@ class TestOpSlicedBlockedArrayCache_masked(object):
 
         # Same request.  Data should be updated now that we're unfrozen.
         data = opCache.Output( slicing ).wait()
-        data.axistags = opCache.Output.meta.axistags
         assert (data == self.data[slicing]).all()
         assert (data.mask == self.data.mask[slicing]).all()
         assert (data.fill_value == self.data.fill_value).all()
@@ -664,7 +654,6 @@ class TestOpSlicedBlockedArrayCache_masked(object):
 
             # Request again.  Data should match this time.
             data = opCache.Output( slicing ).wait()
-            data.axistags = opCache.Output.meta.axistags
             assert (data == self.data[slicing]).all()
             assert (data.mask == self.data.mask[slicing]).all()
             assert (data.fill_value == self.data.fill_value).all()

--- a/tests/testOpSlicedBlockedArrayCache.py
+++ b/tests/testOpSlicedBlockedArrayCache.py
@@ -363,7 +363,7 @@ class TestOpSlicedBlockedArrayCache_masked(object):
         self.data = numpy.ma.masked_array(
             self.data,
             mask=numpy.ma.getmaskarray(self.data),
-            fill_value=numpy.iinfo(self.data.dtype).max,
+            fill_value=self.data.dtype.type(0),
             shrink=False
         )
 

--- a/tests/testOpSlicedBlockedArrayCache.py
+++ b/tests/testOpSlicedBlockedArrayCache.py
@@ -652,7 +652,7 @@ class TestOpSlicedBlockedArrayCache_masked(object):
             #  but fixAtCurrent is True so the cache gives us zeros
             assert (data == 0).all()
             assert (data.mask == False).all()
-            assert (data.fill_value == numpy.iinfo(data.dtype).max).all()
+            assert (data.fill_value == 0).all()
 
             dirty_notifications_received_before = len(gotDirtyKeys)
             opCache.fixAtCurrent.setValue(False)

--- a/tests/testOpSlicedBlockedArrayCache.py
+++ b/tests/testOpSlicedBlockedArrayCache.py
@@ -366,6 +366,7 @@ class TestOpSlicedBlockedArrayCache_masked(object):
             fill_value=self.data.dtype.type(0),
             shrink=False
         )
+        self.data[0, :1, :1, 0, 0] = numpy.ma.masked
 
         graph = Graph()
         opProvider = OpArrayPiperWithAccessCount(graph=graph)

--- a/tests/testOpSplitMaskArray.py
+++ b/tests/testOpSplitMaskArray.py
@@ -25,3 +25,130 @@ __date__ = "$Feb 27, 2015 10:31:24 EST$"
 
 
 
+import numpy
+
+import vigra
+
+from lazyflow.graph import Graph
+from lazyflow.operators.opSplitMaskArray import OpSplitMaskArray
+
+
+class TestOpSplitMaskArray(object):
+    def setUp(self):
+        self.graph = Graph()
+
+        self.operator_split = OpSplitMaskArray(graph=self.graph)
+        self.operator_split.Input.meta.axistags = vigra.AxisTags("txyzc")
+
+    def test1(self):
+        # Generate a random dataset and see if it we get the right masking from the operator.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        mask = numpy.zeros(data.shape, dtype=bool)
+
+        # Mask borders of the expected output.
+        left_slicing = (mask.ndim - 1) * (slice(None),) + (slice(None, 1),)
+        right_slicing = (mask.ndim - 1) * (slice(None),) + (slice(-1, None),)
+        for i in xrange(mask.ndim):
+            left_slicing = left_slicing[-1:] + left_slicing[:-1]
+            right_slicing = right_slicing[-1:] + right_slicing[:-1]
+
+            mask[left_slicing] = True
+            mask[right_slicing] = True
+
+        data = numpy.ma.masked_array(
+            data,
+            mask=mask,
+            fill_value=data.dtype.type(numpy.nan),
+            shrink=False
+        )
+
+        # Provide input read all output.
+        self.operator_split.Input.setValue(data)
+        output_array = self.operator_split.OutputArray[None].wait()
+        output_mask = self.operator_split.OutputMask[None].wait()
+        output_fill_value = self.operator_split.OutputFillValue[None].wait()
+
+        assert not isinstance(output_array, numpy.ma.masked_array)
+        assert not isinstance(output_mask, numpy.ma.masked_array)
+        assert not isinstance(output_fill_value, numpy.ma.masked_array)
+        assert output_array.dtype.type == data.dtype.type
+        assert output_mask.dtype.type == data.mask.dtype
+        assert output_fill_value.dtype.type == data.dtype.type
+        assert (
+            (data.data == output_array) |
+            (numpy.isnan(data.data) & numpy.isnan(output_array))
+        ).all()
+        assert (data.mask == output_mask).all()
+        assert (
+            (data.fill_value[()] == output_fill_value) |
+            (numpy.isnan(data.fill_value[()]) & numpy.isnan(output_fill_value))
+        ).all()
+
+    def test2(self):
+        # Generate a dataset and grab chunks of it from the operator. The result should be the same as above.
+        data = numpy.random.random((4, 5, 6, 7, 3)).astype(numpy.float32)
+        mask = numpy.zeros(data.shape, dtype=bool)
+
+        # Mask borders of the expected output.
+        left_slicing = (mask.ndim - 1) * (slice(None),) + (slice(None, 1),)
+        right_slicing = (mask.ndim - 1) * (slice(None),) + (slice(-1, None),)
+        for i in xrange(mask.ndim):
+            left_slicing = left_slicing[-1:] + left_slicing[:-1]
+            right_slicing = right_slicing[-1:] + right_slicing[:-1]
+
+            mask[left_slicing] = True
+            mask[right_slicing] = True
+
+        data = numpy.ma.masked_array(
+            data,
+            mask=mask,
+            fill_value=data.dtype.type(numpy.nan),
+            shrink=False
+        )
+
+        # Create array to store results. Don't keep original data.
+        output_array = data.data.copy()
+        output_array[:] = 0
+        output_mask = data.mask.copy()
+        output_mask[:] = False
+
+        # Provide input and grab chunks.
+        self.operator_split.Input.setValue(data)
+        output_array[:2] = self.operator_split.OutputArray[:2].wait()
+        output_mask[:2] = self.operator_split.OutputMask[:2].wait()
+        output_array[2:] = self.operator_split.OutputArray[2:].wait()
+        output_mask[2:] = self.operator_split.OutputMask[2:].wait()
+        output_fill_value = self.operator_split.OutputFillValue[None].wait()
+
+        assert not isinstance(output_array, numpy.ma.masked_array)
+        assert not isinstance(output_mask, numpy.ma.masked_array)
+        assert not isinstance(output_fill_value, numpy.ma.masked_array)
+        assert output_array.dtype.type == data.dtype.type
+        assert output_mask.dtype.type == data.mask.dtype
+        assert output_fill_value.dtype.type == data.dtype.type
+        assert (
+            (data.data == output_array) |
+            (numpy.isnan(data.data) & numpy.isnan(output_array))
+        ).all()
+        assert (data.mask == output_mask).all()
+        assert (
+            (data.fill_value[()] == output_fill_value) |
+            (numpy.isnan(data.fill_value[()]) & numpy.isnan(output_fill_value))
+        ).all()
+
+    def tearDown(self):
+        # Take down operators
+        self.operator_split.Input.disconnect()
+        self.operator_split.OutputArray.disconnect()
+        self.operator_split.OutputMask.disconnect()
+        self.operator_split.OutputFillValue.disconnect()
+        self.operator_split.cleanUp()
+
+
+if __name__ == "__main__":
+    import sys
+    import nose
+    sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
+    sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
+    ret = nose.run(defaultTest=__file__)
+    if not ret: sys.exit(1)

--- a/tests/testOpSplitMaskArray.py
+++ b/tests/testOpSplitMaskArray.py
@@ -1,0 +1,27 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#		   http://ilastik.org/license/
+###############################################################################
+
+__author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
+__date__ = "$Feb 27, 2015 10:31:24 EST$"
+
+
+


### PR DESCRIPTION
A continuation of the work done in part 1 ( https://github.com/ilastik/lazyflow/pull/163 ). This work is here to address these outstanding issues ( https://github.com/ilastik/ilastik/issues/1076 ) ( https://github.com/ilastik/lazyflow/issues/162 ) ( https://github.com/ilastik/volumina/issues/151 ).

Makes a few minor changes in lazyflow to ensure masked arrays are copied correctly as there is a bug in NumPy ( https://github.com/numpy/numpy/issues/5558 ). In addition, various caches were modified to ensure that they can properly handle masked arrays. This includes opCompressedCache, OpCompressedUserLabelArray, OpArrayCache, OpBlockedArrayCache, and OpSlicedBlockedArrayCache. Other operators can provide support by following similar strategies. Tests, using masked arrays, were provided for all of these caches. In some cases, test did not exist or were not stringent enough and have since been added or tightened up.