### PR TITLE
tests/testOpFormattedDataExport.py: Fix unsigned rollover issue

### DIFF
--- a/tests/testOpFormattedDataExport.py
+++ b/tests/testOpFormattedDataExport.py
@@ -88,7 +88,11 @@ class TestOpFormattedDataExport(object):
 
         # Due to rounding errors, the actual result and the expected result may differ by 1
         #  e.g. if the original pixel value was 32.99999999
-        difference_from_expected = expected_data - read_data
+        # Also, must promote to signed values to avoid unsigned rollover
+        # See issue ( https://github.com/ilastik/lazyflow/issues/165 ).
+        expected_data_signed = expected_data.astype(numpy.int16)
+        read_data_signed = expected_data.astype(numpy.int16)
+        difference_from_expected = expected_data_signed - read_data_signed
         assert (numpy.abs(difference_from_expected) <= 1).all(), "Read data didn't match exported data!"
         
         opRead.cleanUp()


### PR DESCRIPTION
This is to address ilastik#165. Test fails sometimes due to unsigned rollover issue (i.e. assuming `numpy.uint8` as our type we have `1-2=255`). Here we simply promote to the next largest signed type (i.e. `numpy.int16`). This way, we can still fit all possible values we had before. Also, we can now have `-1`, which puts `numpy.abs` to use.