### PR TITLE
Now open stacks specified via pathseparated filenames

### DIFF
--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -166,7 +166,7 @@ class OpInputDataReader(Operator):
         self.Output.connect( self.opInjector.Output )
     
     def _attemptOpenAsStack(self, filePath):
-        if '*' in filePath:
+        if '*' in filePath or os.path.pathsep in filePath:
             stackReader = OpStackLoader(parent=self)
             stackReader.globstring.setValue(filePath)
             return (stackReader, stackReader.stack)


### PR DESCRIPTION
Small change to enable support for opening stacks from filepaths with pathseparators in them also (not just glob strings)