### PR TITLE
Drtile replacement

### DIFF
--- a/lazyflow/drtile2/__init__.py
+++ b/lazyflow/drtile2/__init__.py
@@ -1,0 +1,23 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#          http://ilastik.org/license/
+###############################################################################
+
+from drtile import drtile

--- a/lazyflow/drtile2/drtile.py
+++ b/lazyflow/drtile2/drtile.py
@@ -36,10 +36,15 @@ def _drtile_old(bool_array):
 
 def _drtile_new(bool_array):
     """
-    tile the true parts of a bool arrray
+    tile the non-zero parts of a bool array into rectangles
  
-    Returns an iterable that contains rois as concatenated start and
+    Returns an iterator that contains rois as concatenated start and
     stop vectors (for a 3-dim array, roi.shape == 6).
+
+    Note: If you want to keep the tiles for more than one iteration, use
+    this function as
+
+    >>> tile_rois = list(drtile(bool_array))
     """
     x = bool_array
 
@@ -59,7 +64,7 @@ def _drtile_new(bool_array):
             for k in current)
 
         # finalize tilings that are not in the current hyperplane
-        final = ifilter(lambda k: k not in current, last_dict)
+        final = ifilter(lambda k: k not in current_dict, last_dict)
         expanded = imap(lambda k: _expand_roi(k, last_dict[k], i), final)
         rois.extend(expanded)
 
@@ -67,7 +72,7 @@ def _drtile_new(bool_array):
 
     # add the remaining tiles
     expanded = imap(lambda k: _expand_roi(k, last_dict[k], x.shape[-1]),
-                    last)
+                    last_dict)
     rois.extend(expanded)
     return rois
 

--- a/lazyflow/drtile2/drtile.py
+++ b/lazyflow/drtile2/drtile.py
@@ -1,0 +1,105 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#          http://ilastik.org/license/
+###############################################################################
+
+from itertools import imap, ifilter
+
+import numpy as np
+import vigra
+
+from lazyflow.drtile import drtile as drtilecpp
+from lazyflow.utility.fastWhere import fastWhere
+
+
+def _drtile_old(bool_array):
+    tileWeights = fastWhere(bool_array, 1, 128**3, np.uint32)
+    return drtilecpp.test_DRTILE(tileWeights, 128**3)
+
+
+def _drtile_new(bool_array):
+    """
+    tile the true parts of a bool arrray
+ 
+    Returns an iterable that contains rois as concatenated start and
+    stop vectors (for a 3-dim array, roi.shape == 6).
+    """
+    x = bool_array
+
+    if x.ndim == 1:
+        return _drtile_1d(x)
+
+    rois = []
+
+    last = _drtile_new(x[..., 0])
+    last_dict = dict((k, 0) for k in last)
+    for i in range(1, x.shape[-1]):
+        # compute tiling in hyperplane
+        current = _drtile_new(x[..., i])
+        # check which tiles are present in last hyperplane
+        current_dict = dict(
+            (k, (i if k not in last else last_dict[k]))
+            for k in current)
+
+        # finalize tilings that are not in the current hyperplane
+        final = ifilter(lambda k: k not in current, last)
+        expanded = imap(lambda k: _expand_roi(k, last_dict[k], i), final)
+        rois.extend(expanded)
+
+        last = current
+        last_dict = current_dict
+
+    # add the remaining tiles
+    expanded = imap(lambda k: _expand_roi(k, last_dict[k], x.shape[-1]),
+                    last)
+    rois.extend(expanded)
+    return rois
+
+def _expand_roi(r, a, b):
+    n = len(r)
+    h = n//2
+    s = list(r)
+    s.insert(h, a)
+    s.append(b)
+    return tuple(s)
+
+def _drtile_1d(x):
+    rois = []
+    current = None
+    for i in range(len(x)):
+        if current is None:
+            # looking for a start
+            if x[i]:
+                current = [i, None]
+        else:
+            # looking for stop
+            if not x[i]:
+                current[1] = i
+                rois.append(tuple(current))
+                current = None
+    if current is not None:
+        # we have an open region left
+        current[1] = len(x)
+        rois.append(tuple(current))
+    return rois
+
+
+# export new style drtile
+drtile = _drtile_new

--- a/lazyflow/drtile2/drtile.py
+++ b/lazyflow/drtile2/drtile.py
@@ -55,15 +55,14 @@ def _drtile_new(bool_array):
         current = _drtile_new(x[..., i])
         # check which tiles are present in last hyperplane
         current_dict = dict(
-            (k, (i if k not in last else last_dict[k]))
+            (k, (i if k not in last_dict else last_dict[k]))
             for k in current)
 
         # finalize tilings that are not in the current hyperplane
-        final = ifilter(lambda k: k not in current, last)
+        final = ifilter(lambda k: k not in current, last_dict)
         expanded = imap(lambda k: _expand_roi(k, last_dict[k], i), final)
         rois.extend(expanded)
 
-        last = current
         last_dict = current_dict
 
     # add the remaining tiles
@@ -80,25 +79,24 @@ def _expand_roi(r, a, b):
     s.append(b)
     return tuple(s)
 
+
 def _drtile_1d(x):
-    rois = []
+    n = len(x)
     current = None
-    for i in range(len(x)):
+    for i in range(n):
         if current is None:
             # looking for a start
             if x[i]:
-                current = [i, None]
+                current = i
         else:
             # looking for stop
             if not x[i]:
-                current[1] = i
-                rois.append(tuple(current))
+                yield ((current, i))
                 current = None
     if current is not None:
         # we have an open region left
-        current[1] = len(x)
-        rois.append(tuple(current))
-    return rois
+        yield ((current, n))
+
 
 
 # export new style drtile

--- a/tests/testDrtile.py
+++ b/tests/testDrtile.py
@@ -128,6 +128,8 @@ class BenchmarkTimer(object):
             x *= 1e3
         if rev:
             x = 1/x
+            x *= 1e3
+            e -= 3
         else:
             e = -e
         return "{:.2f}".format(x) + ("*10^{}".format(e) if e else "")
@@ -135,8 +137,8 @@ class BenchmarkTimer(object):
 if __name__ == "__main__":
     from lazyflow.drtile2.drtile import _drtile_old, _drtile_new
 
-    for n in (5, 10, 20, 30):
-        shape = (n,)*3
+    for n in (5, 10, 20, 30, 40, 50, 100, 1000):
+        shape = (n,)*2
         print("Shape {}".format(shape))
         np.random.seed(0)
         x = np.random.randint(0, 2, size=shape)

--- a/tests/testDrtile.py
+++ b/tests/testDrtile.py
@@ -1,0 +1,147 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#          http://ilastik.org/license/
+###############################################################################
+
+import time
+
+import numpy as np
+import vigra
+import unittest
+
+from lazyflow.drtile2 import drtile
+
+
+class TestDrtile(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test1d(self):
+        x = [1, 1, 0, 1, 0, 0, 1, 1, 1]
+        x = np.asarray(x)
+
+        rois = drtile(x)
+        np.testing.assert_equal(len(rois), 3)
+
+    def testSimple2d(self):
+        x = [[1, 1, 1, 1, 1],
+             [1, 0, 0, 0, 1],
+             [1, 0, 0, 0, 1],
+             [1, 1, 1, 1, 1]]
+        x = np.asarray(x)
+
+        rois = drtile(x)
+        np.testing.assert_equal(len(rois), 4)
+
+    @unittest.expectedFailure
+    def testHard2d(self):
+        x = [[1, 1, 1, 1, 1],
+             [1, 1, 0, 0, 1],
+             [1, 1, 0, 0, 1],
+             [0, 1, 1, 1, 1]]
+        x = np.asarray(x)
+
+        rois = drtile(x)
+        np.testing.assert_equal(len(rois), 4)
+
+    def test3d(self):
+        x = [[1, 1, 1, 1, 1],
+             [1, 0, 0, 0, 1],
+             [1, 0, 0, 0, 1],
+             [1, 1, 1, 1, 1]]
+        x = np.asarray(x)
+
+        
+        y = [[1, 0, 0, 0, 1],
+             [0, 0, 0, 0, 0],
+             [0, 0, 0, 0, 0],
+             [1, 0, 0, 0, 1]]
+        y = np.asarray(y)
+
+        vol = np.concatenate((x[:, :, np.newaxis],
+                              y[:, :, np.newaxis],
+                              y[:, :, np.newaxis],
+                              x[:, :, np.newaxis]), axis=2)
+
+        rois = drtile(vol)
+
+        print(vol.shape)
+        print("ARRAY")
+        print(vol)
+        print("TILING")
+        print(tilingToArray(rois, vol.shape))
+
+        # 2*4 in x arrays and 4 in 2*y
+        np.testing.assert_equal(len(rois), 3*4)
+
+
+def tilingToArray(x, shape):
+    x = np.asarray(x)
+    y = np.zeros(shape, dtype=np.uint32)
+    half = x.shape[1]//2
+    for i in range(x.shape[0]):
+        start = x[i, :half]
+        stop = x[i, half:]
+        key = tuple([slice(a, b) for a, b in zip(start, stop)])
+        y[key] = i+1
+    return y
+
+
+class BenchmarkTimer(object):
+    def __init__(self, benchmarkName, n):
+        self._n = n
+        self._s = benchmarkName
+    def __enter__(self):
+        self._t = time.time()
+
+    def __exit__(self, *args, **kwargs):
+        t = time.time()
+        e = (t-self._t)
+        print("Elapsed time ({}): total={}s, per-pixel={}s"
+              "".format(self._s, self._sci(e), self._sci(e/self._n)))
+
+    def _sci(self, x):
+        e = 0
+        rev = False
+        if x > 1:
+            x = 1/float(x)
+            rev = True
+        while x < 1:
+            e += 3
+            x *= 1e3
+        if rev:
+            x = 1/x
+        else:
+            e = -e
+        return "{:.2f}".format(x) + ("*10^{}".format(e) if e else "")
+
+if __name__ == "__main__":
+    from lazyflow.drtile2.drtile import _drtile_old, _drtile_new
+
+    for n in (5, 10, 20, 30):
+        shape = (n,)*3
+        print("Shape {}".format(shape))
+        np.random.seed(0)
+        x = np.random.randint(0, 2, size=shape)
+
+        for foo, name in [(_drtile_old, "drtile.cpp"),
+                          (_drtile_new, "drtile.py")]:
+            with BenchmarkTimer(name, x.size):
+                roi = foo(x)

--- a/tests/testDrtile.py
+++ b/tests/testDrtile.py
@@ -37,7 +37,7 @@ class TestDrtile(unittest.TestCase):
         x = [1, 1, 0, 1, 0, 0, 1, 1, 1]
         x = np.asarray(x)
 
-        rois = drtile(x)
+        rois = list(drtile(x))
         np.testing.assert_equal(len(rois), 3)
 
     def testSimple2d(self):
@@ -47,7 +47,7 @@ class TestDrtile(unittest.TestCase):
              [1, 1, 1, 1, 1]]
         x = np.asarray(x)
 
-        rois = drtile(x)
+        rois = list(drtile(x))
         np.testing.assert_equal(len(rois), 4)
 
     @unittest.expectedFailure
@@ -58,7 +58,7 @@ class TestDrtile(unittest.TestCase):
              [0, 1, 1, 1, 1]]
         x = np.asarray(x)
 
-        rois = drtile(x)
+        rois = list(drtile(x))
         np.testing.assert_equal(len(rois), 4)
 
     def test3d(self):
@@ -80,13 +80,7 @@ class TestDrtile(unittest.TestCase):
                               y[:, :, np.newaxis],
                               x[:, :, np.newaxis]), axis=2)
 
-        rois = drtile(vol)
-
-        print(vol.shape)
-        print("ARRAY")
-        print(vol)
-        print("TILING")
-        print(tilingToArray(rois, vol.shape))
+        rois = list(drtile(vol))
 
         # 2*4 in x arrays and 4 in 2*y
         np.testing.assert_equal(len(rois), 3*4)


### PR DESCRIPTION
I wrote a pure Python replacement for drtile, which tiles a boolean array into rectangles. For a simple example, see the test file. The test file can also be run standalone to get a benchmark of C++ vs. Python. I have the results from my netbook [here](https://gist.github.com/burgerdev/f3df7e9a50dcc5dc2488). What I see from this is that the performance is

  * worst case half as good as C++
  * for 'normal' tilings still in the order of 10ms

I would consider this alone good enough for replacing the C++ library, but it gets even better. It is strictly beyond me what [the C++ source](https://github.com/ilastik/lazyflow/blob/master/lazyflow/drtile/drtile.cpp#L143) is actually doing, but I figured out that it's not tiling very nice. In fact, an array like this

```
[[1 1 1 1 1]
 [1 1 1 1 1]
 [1 1 0 0 1]
 [1 1 0 0 1]
 [0 1 1 1 1]]
```
is tiled as
```
[[1 2 3 5 7]
 [1 2 3 5 7]
 [1 2 0 0 7]
 [1 2 0 0 7]
 [0 2 4 6 7]]
```
where an optimal solution would look more like
```
[[1 1 2 2 4]
 [1 1 2 2 4]
 [1 1 0 0 4]
 [1 1 0 0 4]
 [0 3 3 3 4]]
```
However, finding the optimal solution  is a packing problem and NP hard if I am not mistaken. But we can do better than just computing vertical tilings. In fact, the python implementation does extend tiles in all dimensions if possible and comes up with this

```
[[1 2 4 4 5]
 [1 2 4 4 5]
 [1 2 0 0 5]
 [1 2 0 0 5]
 [0 2 3 3 5]]
```

which is not optimal but still two requests better than our current version.