### PR TITLE
fixed tifffile import statement

### DIFF
--- a/lazyflow/operators/ioOperators/opTiffReader.py
+++ b/lazyflow/operators/ioOperators/opTiffReader.py
@@ -1,11 +1,11 @@
 import numpy
 
 try:
-    import tiffffile
+    from tifffile import TiffFile, TIFF_SAMPLE_DTYPES
 except ImportError:
     # Skimage supplies a copy of tifffile
-    import skimage.external.tifffile.tifffile_local as tifffile
-from tifffile import TiffFile, TIFF_SAMPLE_DTYPES
+    from skimage.external.tifffile.tifffile_local import\
+        TiffFile, TIFF_SAMPLE_DTYPES
 
 import vigra
 from lazyflow.graph import Operator, InputSlot, OutputSlot


### PR DESCRIPTION
Imports like 
```python
# directory structure: root/a/b/c.py
import a.b
import b.c
```
do not work in my python-2.7.10 on linux.