### PR TITLE
Fixed error in the function create_and_train() of parallelVigraRfLazyflowClassifier.py

### DIFF
--- a/lazyflow/classifiers/parallelVigraRfLazyflowClassifier.py
+++ b/lazyflow/classifiers/parallelVigraRfLazyflowClassifier.py
@@ -38,6 +38,7 @@ class ParallelVigraRfLazyflowClassifierFactory(LazyflowVectorwiseClassifierFacto
         tree_counts[:self._num_trees % self._num_forests] += 1
         assert tree_counts.sum() == self._num_trees
         tree_counts = map(int, tree_counts)
+        tree_counts[:] = (tree_count for tree_count in tree_counts if tree_count != 0)
         
         logger.debug( "Training parallel vigra RF" )
         # Save for future reference


### PR DESCRIPTION
there is an error that can be recreated when the number of trees is less than the number of processors. In the function create_and_train() of parallelVigraRfLazyflowClassifier.py, the list tree_counts has trailing zeros when _num_trees is less than _num_forests.