### PR TITLE
Added MMF and uFMF video reader operators.

### DIFF
--- a/lazyflow/operators/ioOperators/FlyMovieFormat.py
+++ b/lazyflow/operators/ioOperators/FlyMovieFormat.py
@@ -1,0 +1,556 @@
+# FlyMovieFormat.py
+# KMB 11/06/2008
+
+import sys
+import struct
+import warnings
+import os.path
+
+import numpy as nx
+from numpy import nan
+
+import time
+
+import math
+
+# version 1 formats:
+VERSION_FMT = '<I'
+FORMAT_LEN_FMT = '<I'
+BITS_PER_PIXEL_FMT = '<I' 
+FRAMESIZE_FMT = '<II'
+CHUNKSIZE_FMT = '<Q'
+N_FRAME_FMT = '<Q'
+TIMESTAMP_FMT = 'd' # XXX struct.pack('<d',nan) dies
+
+# additional version 2 formats:
+CHUNK_N_FRAME_FMT = '<Q'
+CHUNK_TIMESTAMP_FMT = 'd' # XXX struct.pack('<d',nan) dies
+CHUNK_DATASIZE_FMT = '<Q'
+
+class NoMoreFramesException( Exception ):
+    pass
+    
+class InvalidMovieFileException( Exception ):
+    pass
+    
+class FlyMovie:
+    
+    def __init__(self, filename,check_integrity=False):
+        self.filename = filename
+        try:
+            self.file = open(self.filename,mode="r+b")
+        except IOError:
+            self.file = open(self.filename,mode="r")
+            self.writeable = False
+        else:
+            self.writeable = True
+        
+	# get the extension
+	tmp,ext = os.path.splitext(self.filename)
+	if ext == '.sbfmf':
+	    self.init_sbfmf()
+	    self.issbfmf = True
+	    return
+	else:
+	    self.issbfmf = False
+        
+        r=self.file.read # shorthand
+        t=self.file.tell # shorthand
+        size=struct.calcsize
+        unpack=struct.unpack
+
+        version_buf = r(size(VERSION_FMT))
+        if len(version_buf)!=size(VERSION_FMT):
+            raise InvalidMovieFileException("could not read data file")
+            
+        version, = unpack(VERSION_FMT,version_buf)
+        if version not in (1,3):
+            raise NotImplementedError('Can only read version 1 and 3 files')
+
+        if version  == 1:
+            self.format = 'MONO8'
+            self.bits_per_pixel = 8
+        elif version == 3:
+            format_len = unpack(FORMAT_LEN_FMT,r(size(FORMAT_LEN_FMT)))[0]
+            self.format = r(format_len)
+            self.bits_per_pixel = unpack(BITS_PER_PIXEL_FMT,r(size(BITS_PER_PIXEL_FMT)))[0]
+
+        try:
+            self.framesize = unpack(FRAMESIZE_FMT,r(size(FRAMESIZE_FMT)))
+        except struct.error:
+            raise InvalidMovieFileException('file could not be read')
+
+        self.bytes_per_chunk, = unpack(CHUNKSIZE_FMT,r(size(CHUNKSIZE_FMT)))
+        self.n_frames, = unpack(N_FRAME_FMT,r(size(N_FRAME_FMT)))
+        self.timestamp_len = size(TIMESTAMP_FMT)
+        self.chunk_start = self.file.tell()
+        self.next_frame = None
+
+        if self.bytes_per_chunk != self.bits_per_pixel/8*self.framesize[0]*self.framesize[1] + self.timestamp_len:
+            print "FMF reading will probably end badly:", self.bytes_per_chunk, self.bits_per_pixel, self.framesize, self.timestamp_len, self.bits_per_pixel*self.framesize[0]*self.framesize[1] + self.timestamp_len
+
+	if self.n_frames == 0: # unknown movie length, read to find out
+            # seek to end of the movie
+            self.file.seek(0,2)
+            # get the byte position
+            eb = self.file.tell()
+            # compute number of frames using bytes_per_chunk
+            self.n_frames = int((eb-self.chunk_start)/self.bytes_per_chunk)
+            # seek back to the start
+            self.file.seek(self.chunk_start,0)
+            
+        if check_integrity:
+            n_frames_ok = False
+            while not n_frames_ok:
+                try:
+                    self.get_frame(-1)
+                    n_frames_ok = True
+                except NoMoreFramesException:
+                    self.n_frames -= 1
+	    self.file.seek(self.chunk_start,0) # go back to beginning
+
+        self._all_timestamps = None # cache
+
+    def init_sbfmf(self):
+	
+	#try:
+        # read the version number
+        format = '<I'
+        nbytesver, = struct.unpack(format,self.file.read(struct.calcsize(format)))
+        version = self.file.read(nbytesver)
+        
+        # read header parameters
+        format = '<4IQ'
+        nr,nc,self.n_frames,difference_mode,self.indexloc = \
+	      struct.unpack(format,self.file.read(struct.calcsize(format)))
+
+        # read the background image
+        self.bgcenter = nx.fromstring(self.file.read(struct.calcsize('<d')*nr*nc),'<d')
+        # read the std
+        self.bgstd = nx.fromstring(self.file.read(struct.calcsize('<d')*nr*nc),'<d')
+        
+        # read the index
+        ff = self.file.tell()
+        self.file.seek(self.indexloc,0)
+        self.framelocs = nx.fromstring(self.file.read(self.n_frames*8),'<Q')
+
+	#except:
+        #    raise InvalidMovieFileException('file could not be read')
+
+	if version == "0.1":
+	    self.format = 'MONO8'
+	    self.bits_per_pixel = 8
+
+	self.framesize = (nr,nc)
+	self.bytes_per_chunk = None
+	self.timestamp_len = struct.calcsize('<d')
+        self.chunk_start = self.file.tell()
+        self.next_frame = None
+        self._all_timestamps = None # cache
+
+    def close(self):
+        self.file.close()
+        self.writeable = False
+        self.n_frames = None
+        self.next_frame = None
+        
+    def get_width(self):
+        return self.framesize[1]
+
+    def get_height(self):
+        return self.framesize[0]
+
+    def get_n_frames(self):
+        return self.n_frames
+
+    def get_format(self):
+        return self.format
+
+    def get_bits_per_pixel(self):
+        return self.bits_per_pixel
+
+    def read_some_bytes(self,nbytes):
+        return self.file.read(nbytes)
+
+    def _read_next_frame(self):
+        if self.issbfmf:
+            format = '<Id'
+            try:
+                npixels,timestamp = struct.unpack(format,self.file.read(struct.calcsize(format)))
+                x = self.file.read(npixels*4)
+                idx = nx.fromstring(x,'<I')
+                v = nx.fromstring(self.file.read(npixels*1),'<B')
+                frame = self.bgcenter.copy()
+                frame[idx] = v
+            except:
+                print "sbfmf indexing error", self.file.tell()
+                print len( x )
+                print idx.shape, nx.max( idx )
+                print frame.shape
+                raise
+            frame.shape = self.framesize
+        else:
+            data = self.file.read( self.bytes_per_chunk )
+            if data == '':
+                raise NoMoreFramesException('EOF')
+            if len(data)<self.bytes_per_chunk:
+                raise NoMoreFramesException('short frame')
+            timestamp_buf = data[:self.timestamp_len]
+            timestamp, = struct.unpack(TIMESTAMP_FMT,timestamp_buf)
+
+            frame = nx.fromstring(data[self.timestamp_len:],'<B')
+            frame.shape = self.framesize
+        
+##        if self.format == 'MONO8':
+##            frame = nx.fromstring(data[self.timestamp_len:],nx.uint8)
+##            frame.shape = self.framesize
+##        elif self.format in ('YUV411','YUV422'):
+##            frame = nx.fromstring(data[self.timestamp_len:],nx.uint16)
+##            frame.shape = self.framesize
+##        elif self.format in ('MONO16',):
+##            print 'self.framesize',self.framesize
+##            frame = nx.fromstring(data[self.timestamp_len:],nx.uint8)
+##            frame.shape = self.framesize
+##        else:
+##            raise NotImplementedError("Reading not implemented for %s format"%(self.format,))
+        return frame, timestamp
+        
+    def _read_next_timestamp(self):
+        if self.issbfmf:
+            format = '<Id'
+            self.npixelscurr,timestamp = struct.unpack(format,self.file.read(struct.calcsize(format)))
+            return timestamp
+        read_len = struct.calcsize(TIMESTAMP_FMT)
+        timestamp_buf = self.file.read( read_len )
+        self.file.seek( self.bytes_per_chunk-read_len, 1) # seek to next frame
+        if timestamp_buf == '':
+            raise NoMoreFramesException('EOF')
+        timestamp, = struct.unpack(TIMESTAMP_FMT,timestamp_buf)
+        return timestamp
+        
+    def is_another_frame_available(self):
+        try:
+            if self.next_frame is None:
+                self.next_frame = self._read_next_frame()
+        except NoMoreFramesException:
+            return False
+        return True
+        
+    def get_next_frame(self):
+        if self.next_frame is not None:
+            frame, timestamp = self.next_frame
+            self.next_frame = None
+            return frame, timestamp
+        else:
+            frame, timestamp = self._read_next_frame()
+            return frame, timestamp
+
+    def get_frame(self,frame_number):
+        if frame_number < 0:
+            frame_number = self.n_frames + frame_number
+        if frame_number < 0:
+            raise IndexError("index out of range (n_frames = %d)"%self.n_frames)
+        if self.issbfmf:
+            seek_to = self.framelocs[frame_number]
+        else:
+            seek_to = self.chunk_start+self.bytes_per_chunk*frame_number
+        self.file.seek(seek_to)
+        self.next_frame = None
+        try:
+            x = self.get_next_frame()
+        except:
+            print "error after seeking to", seek_to, "for frame", frame_number
+            raise
+        else:
+            return x
+    
+    def get_all_timestamps(self):
+        if self._all_timestamps is None:
+
+            self._all_timestamps = []
+
+            if self.issbfmf:
+                self.seek(0)
+                format = '<Id'
+                l = struct.calcsize(format)
+                for i in range(self.n_frames):
+                    self.seek(i)
+                    npixels,timestamp = struct.unpack(format,self.file.read(l))
+                    self._all_timestamps.append(timestamp)
+            else:
+                self.seek(0)
+                read_len = struct.calcsize(TIMESTAMP_FMT)
+                while 1:
+                    timestamp_buf = self.file.read( read_len )
+                    self.file.seek( self.bytes_per_chunk-read_len, 1) # seek to next frame
+                    if timestamp_buf == '':
+                        break
+                    timestamp, = struct.unpack(TIMESTAMP_FMT,timestamp_buf)
+                    self._all_timestamps.append( timestamp )
+            self.next_frame = None
+            self._all_timestamps = nx.asarray(self._all_timestamps)
+        return self._all_timestamps
+        
+    def seek(self,frame_number):
+        if frame_number < 0:
+            frame_number = self.n_frames + frame_number
+        if self.issbfmf:
+            seek_to = self.framelocs[frame_number]
+        else:
+            seek_to = self.chunk_start+self.bytes_per_chunk*frame_number
+        self.file.seek(seek_to)
+        self.next_frame = None
+
+    def get_next_timestamp(self):
+        if self.next_frame is not None:
+            frame, timestamp = self.next_frame
+            self.next_frame = None
+            return timestamp
+        else:
+            timestamp = self._read_next_timestamp()
+            return timestamp
+        
+    def get_frame_at_or_before_timestamp(self, timestamp):
+        tss = self.get_all_timestamps()
+        at_or_before_timestamp_cond = tss <= timestamp
+        nz = nx.nonzero(at_or_before_timestamp_cond)
+        if len(nz)==0:
+            raise ValueError("no frames at or before timestamp given")
+        fno = nz[-1]
+        return self.get_frame(fno)
+        
+class FlyMovieSaver:
+    def __init__(self,
+                 filename,
+                 version=1,
+                 seek_ok=True,
+                 
+                 compressor=None,
+                 comp_level=1,
+                 
+                 format=None,
+                 bits_per_pixel=None,
+                 ):
+        """create a FlyMovieSaver instance
+
+        arguments:
+
+          filename
+          version    -- 1, 2, or 3
+          seek_ok    -- is seek OK on this filename?
+
+          For version 2:
+          --------------
+          compressor -- None or 'lzo' (only used if version == 2)
+          comp_level -- compression level (only used if compressed)
+          
+          For version 3:
+          --------------
+          format     -- string representing format (e.g. 'MONO8' or 'YUV422')
+          bits_per_pixel -- number of bytes per pixel (MONO8 = 8, YUV422 = 16)
+          
+
+        """
+
+        # filename
+        path, ext = os.path.splitext(filename)
+        if ext == '':
+            ext = '.fmf'
+        self.filename = path+ext
+
+        # seek_ok
+        if seek_ok:
+            mode = "w+b"
+        else:
+            mode = "wb"
+        self.seek_ok = seek_ok
+            
+        self.file = open(self.filename,mode=mode)
+
+        if version == 1:
+            self.add_frame = self._add_frame_v1
+            self.add_frames = self._add_frames_v1
+        elif version == 2:
+            self.add_frame = self._add_frame_v2
+            self.add_frames = self._add_frames_v2
+        elif version == 3:
+            self.add_frame = self._add_frame_v1
+            self.add_frames = self._add_frames_v1
+        else:
+            raise ValueError('only versions 1, 2, and 3 exist')
+
+        self.file.write(struct.pack(VERSION_FMT,version))
+        
+        if version == 2:
+            self.compressor = compressor
+            if self.compressor is None:
+                self.compressor = 'non'
+                
+            if self.compressor == 'non':
+    	        self.compress_func = lambda x: x
+    	    elif self.compressor == 'lzo':
+    	        import lzo
+    	        self.compress_func = lzo.compress
+    	    else:
+    	        raise ValueError("unknown compressor '%s'"%(self.compressor,))
+    	    assert type(self.compressor) == str and len(self.compressor)<=4
+    	    self.file.write(self.compressor)
+            
+        if version == 3:
+            if type(format) != str:
+                raise ValueError("format must be string (e.g. 'MONO8', 'YUV422')")
+            if type(bits_per_pixel) != int:
+                raise ValueError("bits_per_pixel must be integer")
+            format_len = len(format)
+            self.file.write(struct.pack(FORMAT_LEN_FMT,format_len))
+            self.file.write(format)
+            self.file.write(struct.pack(BITS_PER_PIXEL_FMT,bits_per_pixel))
+            
+            self.format = format
+            self.bits_per_pixel = bits_per_pixel
+        else:
+            self.format = 'MONO8'
+            self.bits_per_pixel = 8
+
+        self.framesize = None
+        
+        self.n_frames = 0
+        self.n_frame_pos = None
+
+    def _add_frame_v1(self,origframe,timestamp=nan):
+        TIMESTAMP_FMT = 'd' # XXX struct.pack('<d',nan) dies
+        frame = nx.asarray(origframe)
+        if self.framesize is None:
+            self._do_v1_header(frame)
+        else:
+            if self.framesize != frame.shape:
+                raise ValueError('frame shape is now %s, but it used to be %s'%(str(frame.shape),str(self.framesize)))
+
+        b1 = struct.pack(TIMESTAMP_FMT,timestamp)
+        self.file.write(b1)
+        if hasattr(origframe,'dump_to_file'):
+            nbytes = origframe.dump_to_file( self.file )
+            assert nbytes == self._bytes_per_image
+        else:
+            if not hasattr(self,'gave_dump_fd_warning'):
+                warnings.warn('could save faster if %s implemented dump_to_file()'%(str(type(origframe)),))
+                self.gave_dump_fd_warning = True
+            b2 = frame.tostring()
+            if len(b2) != self._bytes_per_image:
+                raise ValueError("expected buffer of length %d, got length %d (shape %s)"%(self._bytes_per_image,len(b2),str(frame.shape)))
+            self.file.write(b2)
+        self.n_frames += 1
+
+    def _add_frames_v1(self, frames, timestamps=None):
+        if 0:
+            for frame, timestamp in zip(frames,timestamps):
+                self._add_frame_v1(frame,timestamp)
+        else:
+            if timestamps is None:
+                timestamps = [nan]*len(frames)
+            TIMESTAMP_FMT = 'd' # XXX struct.pack('<d',nan) dies
+            if self.framesize is None:
+                self._do_v1_header(frames[0])
+            else:
+                assert self.framesize == frames[0].shape
+            mega_buffer = ''
+            for frame, timestamp in zip(frames,timestamps):
+                b1 = struct.pack(TIMESTAMP_FMT,timestamp)            
+                mega_buffer += b1
+                b2 = frame.tostring()
+                assert len(b2) == self._bytes_per_image
+                mega_buffer += b2
+            self.file.write(mega_buffer)
+            self.n_frames += len(frames)
+        
+    def _do_v1_header(self,frame):
+        # first frame
+
+        # frame data are always type uint8, so frame shape (width) varies if data format not MONO8
+        self.framesize = frame.shape
+
+        buf = struct.pack(FRAMESIZE_FMT,frame.shape[0],frame.shape[1])
+        self.file.write(buf)
+
+        #bits_per_image = frame.shape[0] * frame.shape[1] * self.bits_per_pixel
+        bits_per_image = frame.shape[0] * frame.shape[1] * 8
+        if bits_per_image % 8 != 0:
+            raise ValueError('combination of frame size and bits_per_pixel make non-byte aligned image')
+        self._bytes_per_image = bits_per_image / 8
+        bytes_per_chunk = self._bytes_per_image + struct.calcsize(TIMESTAMP_FMT)
+
+        buf = struct.pack(CHUNKSIZE_FMT,bytes_per_chunk)
+        self.file.write(buf)
+
+        self.n_frame_pos = self.file.tell()
+
+        buf = struct.pack(N_FRAME_FMT,self.n_frames) # will fill in later
+        self.file.write(buf)
+
+        ####### end of header ###########################
+        
+    def _add_frames_v2(self, frames, timestamps=None):
+        if self.framesize is None:
+            # header stuff dependent on first frame
+            
+            frame = frames[0]
+            assert len(frame.shape) == 2 # must be MxN array
+            self.framesize = frame.shape
+            
+            buf = struct.pack(FRAMESIZE_FMT,frame.shape[0],frame.shape[1])
+            self.file.write(buf)
+            
+            self.n_frame_pos = self.file.tell() # may fill value later
+            buf = struct.pack(N_FRAME_FMT,self.n_frames) 
+            self.file.write(buf)
+            
+            ####### end of header ###########################
+
+        # begin chunk
+        chunk_n_frames = len(frames)
+        if timestamps is None:
+            timestamps = [nan]*chunk_n_frames
+        else:
+            assert len(timestamps) == chunk_n_frames
+
+        buf = struct.pack(CHUNK_N_FRAME_FMT,chunk_n_frames)
+        self.file.write(buf)
+
+        for timestamp in timestamps:
+            self.file.write(struct.pack(CHUNK_TIMESTAMP_FMT,timestamp))
+
+        # generate mega string
+        bufs = [ frame.tostring() for frame in frames ]
+        buf = ''.join(bufs)
+        del bufs
+        compressed_data = self.compress_func(buf)
+        
+        chunk_datasize = len( compressed_data)
+        self.file.write(struct.pack(CHUNK_DATASIZE_FMT,chunk_datasize))
+
+        self.file.write(compressed_data)
+        
+        self.n_frames += chunk_n_frames
+
+    def _add_frame_v2(self,frame,timestamp=nan):
+        self._add_frames_v2([frame],[timestamp])
+
+    def close(self):
+        if self.n_frames == 0:
+            warnings.warn('no frames in FlyMovie')
+            # no frames added
+            self.file.close()
+            del self.file
+            return
+
+        if self.seek_ok:
+            self.file.seek( self.n_frame_pos )
+            buf = struct.pack(N_FRAME_FMT,self.n_frames) # will fill in later
+            self.file.write(buf)
+        self.file.close()
+        del self.file # make sure we can't access self.file again
+
+    def __del__(self):
+        if hasattr(self,'file'):
+            self.close()
+

--- a/lazyflow/operators/ioOperators/FlyMovieFormat.py
+++ b/lazyflow/operators/ioOperators/FlyMovieFormat.py
@@ -13,6 +13,9 @@ import time
 
 import math
 
+import logging
+logger = logging.getLogger(__name__)
+
 # version 1 formats:
 VERSION_FMT = '<I'
 FORMAT_LEN_FMT = '<I'
@@ -87,7 +90,7 @@ class FlyMovie:
         self.next_frame = None
 
         if self.bytes_per_chunk != self.bits_per_pixel/8*self.framesize[0]*self.framesize[1] + self.timestamp_len:
-            print "FMF reading will probably end badly:", self.bytes_per_chunk, self.bits_per_pixel, self.framesize, self.timestamp_len, self.bits_per_pixel*self.framesize[0]*self.framesize[1] + self.timestamp_len
+            logger.warn("FMF reading will probably end badly: {}, {}, {}, {}, {}".format(self.bytes_per_chunk, self.bits_per_pixel, self.framesize, self.timestamp_len, self.bits_per_pixel*self.framesize[0]*self.framesize[1] + self.timestamp_len) )
 
 	if self.n_frames == 0: # unknown movie length, read to find out
             # seek to end of the movie
@@ -183,10 +186,10 @@ class FlyMovie:
                 frame = self.bgcenter.copy()
                 frame[idx] = v
             except:
-                print "sbfmf indexing error", self.file.tell()
-                print len( x )
-                print idx.shape, nx.max( idx )
-                print frame.shape
+                logger.warn("sbfmf indexing error: {}".format(self.file.tell()) )
+                logger.warn( "{}".format(len( x ) ) )
+                logger.warn( "{}".format( idx.shape, nx.max( idx ) ) )
+                logger.warn( "{}".format( frame.shape ) )
                 raise
             frame.shape = self.framesize
         else:
@@ -259,7 +262,7 @@ class FlyMovie:
         try:
             x = self.get_next_frame()
         except:
-            print "error after seeking to", seek_to, "for frame", frame_number
+            logger.warn( "error after seeking to {} for frame {}".format(seek_to, frame_number) )
             raise
         else:
             return x

--- a/lazyflow/operators/ioOperators/MmfParser.py
+++ b/lazyflow/operators/ioOperators/MmfParser.py
@@ -1,0 +1,212 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#           http://ilastik.org/license/
+###############################################################################
+
+import struct
+import numpy as np
+
+# Header IDs
+FILE_HEADER_ID = 0xa3d2d45d
+STACK_HEADER_ID = 0xbb67ca20
+IMAGE_HEADER_ID = 0xf80921af
+
+class MmfParser(object):
+    # Initialize information to seek frames
+    _frameSeekInfo = []
+    
+    # Constructor
+    def __init__(self, fileName) :
+        self._frameCount = None
+        self._bkgImgSeekPos = None
+        
+        try:
+            self.mmfFile = open(fileName, "rb")
+        except FileNotFoundError:
+            print "Wrong file or file path."
+        
+        # Find header id code (and skip ASCII description)
+        while struct.unpack('1I',self.mmfFile.read(4))[0] != FILE_HEADER_ID :
+                self.mmfFile.seek(-3,1)
+        
+        fileHeaderSize = struct.unpack('1i',self.mmfFile.read(4))[0]
+        
+        self.keyFrameInterval = struct.unpack('1i',self.mmfFile.read(4))[0]
+        self.thresholdBelowBackground = struct.unpack('1i',self.mmfFile.read(4))[0]
+        self.thresholdAboveBackground = struct.unpack('1i',self.mmfFile.read(4))[0]
+        
+        # Seek self.mmfFile by the number of self.mmfFile header bytes offset (10240?)
+        self.mmfFile.seek(fileHeaderSize, 0)
+        
+        firstBkgImg = False
+        
+        # Loop through each background image
+        while True :    
+            stackStartPos = self.mmfFile.tell()
+            
+            # Reached end of file
+            buf = self.mmfFile.read(4)
+            if not buf :
+                break
+            
+            stackIdCode = struct.unpack('1I',buf)[0]
+            
+            if  stackIdCode != STACK_HEADER_ID :
+                print "Error: Background image header id code does not match."
+            
+            stackHeaderSize = struct.unpack('1i',self.mmfFile.read(4))[0]
+            stackSize = struct.unpack('1i',self.mmfFile.read(4))[0]
+            stackFrameNum = struct.unpack('1i',self.mmfFile.read(4))[0]
+            
+            # Got to end of stack header
+            self.mmfFile.seek(stackStartPos + stackHeaderSize, 0)
+            
+            bkgHeaderSize = struct.unpack('1i',self.mmfFile.read(4))[0]
+            
+            # Read background image meta-data (only for the first frame)
+            if not firstBkgImg :
+                bkgIdCode =  struct.unpack('1I',self.mmfFile.read(4))[0] # <-- TO DO: This ID is not included in the docs
+                
+                bkgChannelNum =  struct.unpack('1i',self.mmfFile.read(4))[0]
+                if bkgChannelNum != 1 :
+                    print 'Cannot read multichannel data yet: TODO'
+                
+                bkgAlphaChannel =  struct.unpack('1i',self.mmfFile.read(4))[0]
+                
+                bkgDepth =  struct.unpack('1i',self.mmfFile.read(4))[0]
+                if bkgDepth != 8 :
+                    print 'Cannot read non-8-bit depth images yet: TODO'
+                
+                bkgColorModel =  struct.unpack('4c',self.mmfFile.read(4))[0]
+                bkgChannelSeq =  struct.unpack('4c',self.mmfFile.read(4))[0]
+                bkgDataOrder =  struct.unpack('1i',self.mmfFile.read(4))[0]
+                bkgOrigin =  struct.unpack('1i',self.mmfFile.read(4))[0]
+                bkgAlign = struct.unpack('1i',self.mmfFile.read(4))[0]
+                self.bkgWidth =  struct.unpack('1i',self.mmfFile.read(4))[0]
+                self.bkgHeight =  struct.unpack('1i',self.mmfFile.read(4))[0]
+                
+                # image ROI. if NULL, the whole image is selected
+                bkgRoi =  struct.unpack('1I',self.mmfFile.read(4))[0]
+                
+                # must be NULL
+                bkgMaskRoi = struct.unpack('1I',self.mmfFile.read(4))[0]
+                
+                # must be NULL
+                bkgImageId = struct.unpack('1I',self.mmfFile.read(4))[0]
+                
+                # must be NULL
+                bkgTileInfo = struct.unpack('1I',self.mmfFile.read(4))[0]
+                
+                # image data size in bytes (==image->height*image->widthStep in case of interleaved data)
+                self.bkgImgSize = struct.unpack('1i',self.mmfFile.read(4))[0]
+                bkgdim_imagedata = struct.unpack('1I',self.mmfFile.read(4))[0]
+                # Size of aligned image row in bytes
+                self.bkgImgWidthStep = struct.unpack('1i',self.mmfFile.read(4))[0]
+                
+                # ignored
+                bkgBorderMode = struct.unpack('4i',self.mmfFile.read(4*4))[0]
+                
+                # ignored
+                bkgBorderConst = struct.unpack('4i',self.mmfFile.read(4*4))[0]
+                
+                # pointer to something
+                bkgImgDataOrigin = struct.unpack('1I',self.mmfFile.read(4))[0]
+                
+                bkgImgSeekPos = self.mmfFile.tell()
+            else :
+                # Skip reading background image meta-data
+                self.mmfFile.seek(stackStartPos + stackHeaderSize + bkgHeaderSize, 0)
+                bkgImgSeekPos = self.mmfFile.tell()
+            
+            self.mmfFile.seek(self.bkgImgSize, 1)
+            
+            # Read the diff image data (these are usually the tiles that contain the larvae/flies)
+            for fri in range (stackFrameNum) : 
+                imgStartPos = self.mmfFile.tell()
+                
+                imgIdCode = struct.unpack('1I',self.mmfFile.read(4))[0]
+                
+                if imgIdCode != IMAGE_HEADER_ID :
+                    print "Image ID does not match."
+                
+                imgHeaderSize = struct.unpack('1i',self.mmfFile.read(4))[0]
+                self.mmfFile.seek(8,1)
+                imgBlockNum = struct.unpack('1i',self.mmfFile.read(4))[0]
+                
+                self.mmfFile.seek(imgStartPos + imgHeaderSize, 0)
+        
+                imgSeekPos = self.mmfFile.tell()
+        
+                self._frameSeekInfo.append( {"bkgImgSeekPos" : bkgImgSeekPos, "imgSeekPos" : imgSeekPos, "blockNum" :  imgBlockNum} )
+        
+                # Loop through each block        
+                for bki in range(imgBlockNum) :
+                    imgBlockRect = struct.unpack('4i',self.mmfFile.read(4*4))
+                    self.mmfFile.seek(imgBlockRect[2]*imgBlockRect[3], 1)
+
+    def seek(self, frameCount) :
+        self._frameCount = frameCount
+
+    def getFrame(self, frameCount) :
+        self._frameCount = frameCount
+
+        if self._bkgImgSeekPos != self._frameSeekInfo[self._frameCount]['bkgImgSeekPos'] :
+            self._bkgImgSeekPos = self._frameSeekInfo[self._frameCount]['bkgImgSeekPos']
+                
+            self.mmfFile.seek(self._bkgImgSeekPos, 0)
+            
+            self._bkgImg = np.array(struct.unpack(str(self.bkgImgSize) + 'B', self.mmfFile.read(self.bkgImgSize)), dtype='uint8')
+            self._bkgImg = np.reshape(self._bkgImg, (self.bkgHeight, self.bkgImgWidthStep))
+            self._bkgImg = self._bkgImg[:, 0:self.bkgWidth]
+            
+        img = np.copy(self._bkgImg)
+        
+        self.mmfFile.seek(self._frameSeekInfo[self._frameCount]['imgSeekPos'], 0)
+        
+        blockNum = self._frameSeekInfo[self._frameCount]['blockNum'] 
+        for bki in range(blockNum) :
+            imgBlockRect = struct.unpack('4i',self.mmfFile.read(4*4))
+                    
+            byteNumStr = str(imgBlockRect[2]*imgBlockRect[3])
+                        
+            imgBlockData = np.array(struct.unpack(byteNumStr + 'B', self.mmfFile.read(imgBlockRect[2]*imgBlockRect[3])), dtype='uint8')
+            imgBlockData = np.reshape(imgBlockData, (imgBlockRect[3],imgBlockRect[2]) )
+                    
+            img[imgBlockRect[1]:imgBlockRect[1]+imgBlockRect[3], imgBlockRect[0]:imgBlockRect[0]+imgBlockRect[2]] = imgBlockData  
+            
+        return img
+            
+    def getNextFrame(self):
+        nextFrame = self._frameCount + 1
+        return self.getFrame(nextFrame)
+
+    def getNumberOfFrames(self):
+        return len(self._frameSeekInfo)
+
+    def close(self) :
+        self.mmfFile.close()
+
+
+
+
+
+
+
+

--- a/lazyflow/operators/ioOperators/MmfParser.py
+++ b/lazyflow/operators/ioOperators/MmfParser.py
@@ -20,6 +20,30 @@
 #           http://ilastik.org/license/
 ###############################################################################
 
+'''
+MMF reader adapted from JAABA's mmf header reader: https://github.com/kristinbranson/JAABA/blob/master/filehandling/mmf_read_header.m
+
+mmf format documentation (Copied from JAABA's mmf_read_header.m):
+Set of Image Stacks representing a movie. Beginning of file is a header, with this format:
+10240 byte zero padded header beginning with a textual description of the file, followed by \0 then the following fields (all ints, except idcode)
+4 byte unsigned long idcode = a3d2d45d, header size in bytes, key frame interval, threshold below background, threshold above background
+Header is followed by a set of common background image stacks, with the following format:
+Stack of common background images, beginning with this header:
+512 byte zero-padded header, with the following fields (all 4 byte ints, except idcode):
+4 byte unsigned long idcode = bb67ca20, header size in bytes, total size of stack on disk, nframes: number of images in stack
+Then the background image, as an IplImage, starting with the 112 byte image header, followed by the image data
+Then nframes background removed images containing only differences from the background, in this format:
+BackgroundRemovedImage: header is a1024 byte zero padded header with the following data fields (all 4 byte ints, except id code)
+4 byte unsigned long idcode = f80921af, headersize (number of bytes in header), depth (IplImage depth), nChannels (IplImage number of channels), numims (number of 
+image blocks that differ from background) then metadata:
+Name-Value MetaData: idcode (unsigned long) = c15ac674, int number of key-value pairs stored, then each pair
+in the format \0-terminated string of chars then 8 byte double value
+header is followed by numims image blocks of the following form:
+(16 bytes) CvRect [x y w h] describing location of image data, then interlaced row ordered image data
+
+TODO: handle multichannel data, non 8-bit data
+'''
+
 import struct
 import numpy as np
 

--- a/lazyflow/operators/ioOperators/UfmfParser.py
+++ b/lazyflow/operators/ioOperators/UfmfParser.py
@@ -1,0 +1,1595 @@
+from __future__ import division
+import sys
+import struct, collections
+import warnings
+import os.path, hashlib
+import os, stat
+
+import numpy
+import numpy as np
+from numpy import nan
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+import time
+
+import math
+
+import FlyMovieFormat as FMF
+
+class UfmfError(Exception):
+    pass
+
+class ShortUFMFFileError(UfmfError):
+    pass
+
+class CorruptIndexError(UfmfError):
+    pass
+
+class BaseDict(dict):
+    def __getattr__(self,name):
+        return self[name]
+    def __setattr__(self,name,value):
+        self[name]=value
+
+FMT = {1:BaseDict(HEADER = '<IIdII', # version, ....
+                  CHUNKHEADER = '<dI',
+                  SUBHEADER = '<II',
+                  TIMESTAMP = 'd', # XXX struct.pack('<d',nan) dies
+                  ),
+
+       3:BaseDict(HEADER = '<4sIQHHB', # 'ufmf', version, index location,
+                                       # max w, max h, raw coding string length
+                  CHUNKID = '<B', # 0 = keyframe, 1 = points
+                  KEYFRAME1 = '<B', # (type name)
+                  KEYFRAME2 = '<cHHd', # (dtype, width,height,timestamp)
+                  POINTS1 = '<dH', # timestamp, n_pts
+                  POINTS2 = '<HHHH', # x0, y0, w, h
+                  ),
+
+       # Format 2 is the same as format 3, but the index must be at < 4 GB
+       2:BaseDict(HEADER = '<4sILHHB', # 'ufmf', version, index location,
+                                       # max w, max h, raw coding string length
+                  CHUNKID = '<B', # 0 = keyframe, 1 = points
+                  KEYFRAME1 = '<B', # (type name)
+                  KEYFRAME2 = '<cHHd', # (dtype, width,height,timestamp)
+                  POINTS1 = '<dH', # timestamp, n_pts
+                  POINTS2 = '<HHHH', # x0, y0, w, h
+                  ),
+
+       # Format 4 is the same as format 3, except it allows for width
+       # and height of boxes to be fixed and encoded only once
+
+       4:BaseDict(HEADER = '<4sIQHHBB', # 'ufmf', version, index location,
+                                        # max w, max h, isfixedsize,
+                                        # raw coding string length
+                  CHUNKID = '<B', # 0 = keyframe, 1 = points
+                  KEYFRAME1 = '<B', # (type name)
+                  KEYFRAME2 = '<cHHd', # (dtype, width,height,timestamp)
+                  POINTS1 = '<dI', # timestamp, n_pts
+                  POINTS2 = '<HHHH', # x0, y0, w, h
+                  POINTS3 = '<HH', #x0, y0 -- for fixed size boxes
+                  ),
+
+       }
+
+KEYFRAME_CHUNK = 0
+FRAME_CHUNK = 1
+INDEX_DICT_CHUNK = 2
+
+class NoMoreFramesException (Exception):
+    pass
+
+class InvalidMovieFileException (Exception):
+    pass
+
+class UfmfParser(object):
+    """derive from this class to create your own parser
+
+    you will need to implemented the following functions:
+
+    def handle_bg(self, timestamp0, bg_im):
+        pass
+
+    def handle_frame(self, timestamp, regions):
+        pass
+    """
+    def parse(self,filename):
+        ufmf = Ufmf(filename)
+        bg_im, timestamp0 = ufmf.get_bg_image()
+
+        self.handle_bg(timestamp0, bg_im)
+
+        while 1:
+            buf = fd.read( chunkheadsz )
+            if len(buf)!=chunkheadsz:
+                # no more frames (EOF)
+                break
+            intup = struct.unpack(FMT[1].CHUNKHEADER, buf)
+            (timestamp, n_pts) = intup
+            regions = []
+            for ptnum in range(n_pts):
+                subbuf = fd.read(subsz)
+                intup = struct.unpack(FMT[1].SUBHEADER, subbuf)
+                xmin, ymin = intup
+
+                buf = fd.read( chunkimsize )
+                bufim = numpy.fromstring( buf, dtype = numpy.uint8 )
+                bufim.shape = chunkheight, chunkwidth
+                regions.append( (xmin,ymin, bufim) )
+
+            self.handle_frame(timestamp, regions)
+        fd.close()
+
+def identify_ufmf_version(filename):
+    mode = "rb"
+    fd = open(filename,mode=mode)
+    VERSION_FMT = '<I' # always the first bytes
+    version_buflen = struct.calcsize(VERSION_FMT)
+    version_buf = fd.read( version_buflen )
+    had_marker=False
+    if version_buf=='ufmf':
+        version_buf = fd.read( version_buflen )
+        had_marker=True
+    version, = struct.unpack(VERSION_FMT, version_buf)
+    if version>1:
+        if not had_marker:
+            raise ValueError('ill-formed .ufmf file')
+    if version==1:
+        if had_marker:
+            raise ValueError('ill-formed .ufmf file')
+    fd.close()
+    return version
+
+def _write_dict(fd,save_dict):
+    fd.write('d')
+    fd.write(chr(len(save_dict.keys())))
+    keys = save_dict.keys()
+    keys.sort() # keep ordering fixed to file remains same if re-indexed
+    for key in keys:
+        value = save_dict[key]
+        b = struct.pack('<H',len(key))
+        b += key
+        fd.write(b)
+        if isinstance(value,dict):
+            _write_dict(fd,value)
+            continue
+        if isinstance(value,list) or isinstance(value,np.ndarray):
+            larr = np.array(value)
+            assert larr.ndim==1
+            dtype_char = larr.dtype.char
+            bytes_per_element = larr.dtype.itemsize
+            b = 'a'+dtype_char+struct.pack('<L',len(larr)*bytes_per_element)
+            b += larr.tostring()
+            fd.write(b)
+            continue
+        raise ValueError("don't know how to save value %s"%(value,))
+
+def _read_min_chars(fd,keylen,buf_remaining):
+    if len(buf_remaining)>=keylen:
+        x = buf_remaining[:keylen]
+        buf_remaining = buf_remaining[keylen:]
+        return x,buf_remaining
+    else:
+        readlen = max(4096,keylen - len(buf_remaining))
+        newbuf = fd.read(readlen)
+        buf_remaining = buf_remaining+newbuf
+        # if we can't read in enough from the file
+        if len(buf_remaining) < keylen:
+            return _read_min_chars(fd,len(buf_remaining),buf_remaining)
+        else:
+            return _read_min_chars(fd,keylen,buf_remaining)
+
+def _read_array(fd,buf_remaining):
+    x,buf_remaining = _read_min_chars(fd,1,buf_remaining)
+    dtype_char = x
+
+    n_bytes_calcsize = struct.calcsize('<L')
+    x,buf_remaining = _read_min_chars(fd,n_bytes_calcsize,buf_remaining)
+    n_bytes_buf=x
+    n_bytes, = struct.unpack('<L',n_bytes_buf)
+
+    data_buf,buf_remaining = _read_min_chars(fd,n_bytes,buf_remaining)
+    larr = np.fromstring(data_buf,dtype=dtype_char)
+    return larr, buf_remaining
+
+def _read_dict(fd,buf_remaining=None):
+    if buf_remaining is None:
+        buf_remaining=''
+    x,buf_remaining = _read_min_chars(fd,1,buf_remaining)
+    n_keys = ord(x)
+    result = {}
+    Hsize = struct.calcsize('<H')
+    for key_num in range(n_keys):
+        x,buf_remaining = _read_min_chars(fd,Hsize,buf_remaining)
+        keylen, = struct.unpack('<H',x)
+        x,buf_remaining = _read_min_chars(fd,keylen,buf_remaining)
+        key = x
+        x,buf_remaining = _read_min_chars(fd,1,buf_remaining)
+        id = x
+        if id=='d':
+            value,buf_remaining = _read_dict(fd,buf_remaining)
+        elif id=='a':
+            value,buf_remaining = _read_array(fd,buf_remaining)
+        else:
+            raise ValueError("don't know how to read value with id %s"%(id,))
+        #assert key not in value
+        result[key] = value
+    return result,buf_remaining
+
+def minimize_rectangle_coverage( overlap_rects, rectangle_penalty=0 ):
+    """reduce overlap in set of rectangles covering the union of input rects
+
+    rectangle_penalty - a penalty for each additional rectangle, used
+      to discourage small rectangles
+
+    See, for example:
+
+    Heinrich-Litan and Luebbecke (2006), Rectangle
+    covers revisited computationally, J. Exp. Algorithmics
+
+    Ferrari, Sankar, Sklansky (1984) Minimal Rectangular Partitions of
+    Digitized Blobs. Computer Vision, Graphics, and Image Processing.
+
+    """
+    warnings.warn('not implemented: minimize_rectangle_coverage')
+    return overlap_rects
+
+def Ufmf(filename,**kwargs):
+    """factory function to return UfmfBase class instance"""
+    version = identify_ufmf_version(filename)
+    if version==1:
+        return UfmfV1(filename,**kwargs)
+    elif version==2:
+        if 'seek_ok' in kwargs:
+            kwargs.pop('seek_ok')
+        return UfmfV2(filename,**kwargs)
+    elif version==3:
+        if 'seek_ok' in kwargs:
+            kwargs.pop('seek_ok')
+        return UfmfV3(filename,**kwargs)
+    elif version==4:
+        if 'seek_ok' in kwargs:
+            kwargs.pop('seek_ok')
+        return UfmfV4(filename,**kwargs)
+    else:
+        raise ValueError('unknown .ufmf version %d'%version)
+
+class UfmfBase(object):
+    pass
+
+class UfmfV1(UfmfBase):
+    """class to read .ufmf version 1 files"""
+    bufsz = struct.calcsize(FMT[1].HEADER)
+    chunkheadsz = struct.calcsize( FMT[1].CHUNKHEADER )
+    subsz = struct.calcsize(FMT[1].SUBHEADER)
+
+    def __init__(self,filename,
+                 seek_ok=True,
+                 use_conventional_named_mean_fmf=True,
+                 ):
+        super(UfmfV1,self).__init__()
+        mode = "rb"
+        self._filename = filename
+        self._fd = open(filename,mode=mode)
+        buf = self._fd.read( self.bufsz )
+        intup = struct.unpack(FMT[1].HEADER, buf)
+        (self._version, self._image_radius,
+         self._timestamp0,
+         self._width, self._height) = intup
+        # extract background
+        bg_im_buf = self._fd.read( self._width*self._height)
+        self._bg_im = numpy.fromstring( bg_im_buf, dtype=numpy.uint8)
+        self._bg_im.shape = self._height, self._width
+        if hasattr(self,'handle_bg'):
+            self.handle_bg(self._timestamp0, self._bg_im)
+
+        # get ready to extract frames
+        self._chunkwidth = 2*self._image_radius
+        self._chunkheight = 2*self._image_radius
+        self._chunkshape = self._chunkheight, self._chunkwidth
+        self._chunkimsize = self._chunkwidth*self._chunkheight
+        self._last_safe_x = self._width - self._chunkwidth
+        self._last_safe_y = self._height - self._chunkheight
+        if seek_ok:
+            self._fd_start = self._fd.tell()
+            self._fd.seek(0,2)
+            self._fd_end = self._fd.tell()
+            self._fd.seek(self._fd_start,0)
+            self._fd_length = self._fd_end - self._fd_start
+        else:
+            self._fd_length = None
+
+        self.use_conventional_named_mean_fmf = use_conventional_named_mean_fmf
+        self._sumsqf_fmf = None
+        if self.use_conventional_named_mean_fmf:
+            basename = os.path.splitext(self._filename)[0]
+            fmf_filename = basename + '_mean.fmf'
+            if os.path.exists(fmf_filename):
+                self._mean_fmf = FMF.FlyMovie(fmf_filename)
+                self._mean_fmf_timestamps = self._mean_fmf.get_all_timestamps()
+                dt=self._mean_fmf_timestamps[1:]-self._mean_fmf_timestamps[:-1]
+                assert np.all(dt > 0) # make sure searchsorted will work
+
+                sumsqf_filename = basename + '_sumsqf.fmf'
+                if os.path.exists(sumsqf_filename):
+                    self._sumsqf_fmf = FMF.FlyMovie(sumsqf_filename)
+            else:
+                self.use_conventional_named_mean_fmf = False
+
+    def get_mean_for_timestamp(self, timestamp, _return_more=False ):
+        if not hasattr(self,'_mean_fmf_timestamps'):
+            raise ValueError(
+                'ufmf %s does not have mean image data'%self._filename)
+        fno=np.searchsorted(self._mean_fmf_timestamps,timestamp,side='right')-1
+        mean_image, timestamp_mean = self._mean_fmf.get_frame(fno)
+        assert timestamp_mean <= timestamp
+        if _return_more:
+            # assume same times as mean image
+            sumsqf_image, timestamp_sumsqf = self._sumsqf_fmf.get_frame(fno)
+            return mean_image, sumsqf_image
+        else:
+            return mean_image
+
+    def get_bg_image(self):
+        """return the background image"""
+        return self._bg_im, self._timestamp0
+
+    def get_progress(self):
+        """get a fraction of completeness (approximate value)"""
+        if self._fd_length is None:
+            # seek_ok was false - don't know how long this is
+            return 0.0
+        dist = self._fd.tell()-self._fd_start
+        return dist/self._fd_length
+
+    def tell(self):
+        return self._fd.tell()
+
+    def seek(self,loc):
+        self._fd.seek(loc)
+
+    def readframes(self):
+        """return a generator of the frame information"""
+        while 1:
+            buf = self._fd.read( self.chunkheadsz )
+            if len(buf)!=self.chunkheadsz:
+                # no more frames (EOF)
+                break
+            intup = struct.unpack(FMT[1].CHUNKHEADER, buf)
+            (timestamp, n_pts) = intup
+
+            regions = []
+            for ptnum in range(n_pts):
+                subbuf = self._fd.read(self.subsz)
+                intup = struct.unpack(FMT[1].SUBHEADER, subbuf)
+                xmin, ymin = intup
+
+                if (xmin < self._last_safe_x and
+                    ymin < self._last_safe_y):
+                    read_length = self._chunkimsize
+                    bufshape = self._chunkshape
+                else:
+                    chunkwidth = min(self._width - xmin, self._chunkwidth)
+                    chunkheight = min(self._height - ymin, self._chunkheight)
+                    read_length = chunkwidth*chunkheight
+                    bufshape = chunkheight,chunkwidth
+                buf = self._fd.read( read_length )
+                bufim = numpy.fromstring( buf, dtype = numpy.uint8 )
+                bufim.shape = bufshape
+                regions.append( (xmin,ymin, bufim) )
+            yield timestamp, regions
+
+    def close(self):
+        self._fd.close()
+
+class _UFmfV3LowLevelReader(object):
+    def __init__(self,fd,version):
+        self._fd = fd
+        self._version = version
+        self._coding = ''
+
+        self._keyframe2_sz = struct.calcsize(FMT[self._version].KEYFRAME2)
+        self._points1_sz =   struct.calcsize(FMT[self._version].POINTS1)
+        self._points2_sz =   struct.calcsize(FMT[self._version].POINTS2)
+
+    def set_coding(self,coding):
+        self._coding = coding.lower()
+        # added by KB:
+        if self._coding == 'rgb24':
+            self._bytesperpixel = 3
+        elif self._coding == 'mono8':
+            self._bytesperpixel = 1
+        else:
+            self._bytesperpixel = 1
+            raise NotImplementedError('Color coding %s not yet implemented'%self._coding)
+
+    def _read_keyframe_chunk(self):
+        """read keyframe chunk from just after chunk_id byte
+
+        start_location is the file locate at which the chunk started.
+        (i.e. curpos-1)
+        """
+        len_type = ord(self._fd_read(1))
+        keyframe_type = self._fd_read(len_type)
+        assert len(keyframe_type)==len_type
+        intup = struct.unpack(FMT[self._version].KEYFRAME2,
+                              self._fd_read(self._keyframe2_sz))
+        dtype_char,width,height,timestamp=intup
+
+        if dtype_char=='B':
+            dtype=np.uint8
+            sz=1
+        elif dtype_char=='f':
+            dtype=np.float32
+            sz=4
+        else:
+            raise ValueError('unknown dtype char "%s" (0x%0x)'%(dtype_char,
+                                                                ord(dtype_char)))
+        # added by KB:
+        # read in RGB24 data
+        # the data is indexed by column, then row, then color
+        # colors are in the order RGB.
+        if self._coding == 'rgb24':
+            read_len = width*height*sz*self._bytesperpixel
+            buf = self._fd_read(read_len)
+            frame = np.fromstring(buf,dtype=dtype)
+            frame.shape = (3,height,width)
+            frame = frame.transpose((1,2,0))
+        elif self._coding == 'mono8':
+            read_len = width*height*sz
+            buf = self._fd_read(read_len)
+            frame = np.fromstring(buf,dtype=dtype)
+            frame.shape = (height,width)
+        else:
+            raise NotImplementedError('Color coding %s not yet implemented'%self._coding)
+        return keyframe_type,frame,timestamp
+
+    def _read_frame_chunk(self):
+        """read frame chunk from just after chunk_id byte
+
+        start_location is the file locate at which the chunk started
+        (i.e. curpos-1)
+        """
+        intup = struct.unpack(FMT[self._version].POINTS1,
+                              self._fd_read(self._points1_sz))
+        timestamp, n_pts = intup
+
+        regions = []
+        for ptno in range(n_pts):
+            intup = struct.unpack(FMT[self._version].POINTS2,
+                                  self._fd_read(self._points2_sz))
+            (xmin, ymin, w, h) = intup
+            # added by KB
+            # read in RGB24 data
+            # the data is indexed by column, then row, then color
+            # colors are in the order RGB.
+            if self._coding == 'rgb24':
+                lenbuf = w*h*self._bytesperpixel
+                buf = self._fd_read(lenbuf)
+                im = np.fromstring(buf,dtype=np.uint8)
+                im.shape = (self._bytesperpixel,h,w)
+                im = im.transpose((1,2,0))
+            elif self._coding == 'mono8':
+                lenbuf = w*h
+                buf = self._fd_read(lenbuf)
+                im = np.fromstring(buf,dtype=np.uint8)
+                im.shape = (h,w)
+            else:
+                raise NotImplementedError('Color coding %s not yet implemented'%self._coding)
+            regions.append( (xmin,ymin,im) )
+        return timestamp,regions
+
+    def _fd_read(self,n_bytes,short_OK=False):
+        buf = self._fd.read(n_bytes)
+        if len(buf)!=n_bytes:
+            if not short_OK:
+                raise ShortUFMFFileError('expected %d bytes, got %d: short file %s?'%(
+                    n_bytes,len(buf), self._fd.name))
+        return buf
+
+# V4 added by KB
+# Main difference from V3: allows fixed-size UFMFs
+class _UFmfV4LowLevelReader(_UFmfV3LowLevelReader):
+
+    # Set parameters not set in V3
+    # We don't do this in __init__ because these require the header
+    # to have been read already.
+    def set_params(self,max_width,max_height,isfixedsize):
+        # whether the boxes are fixed size
+        self._isfixedsize = isfixedsize
+        # if fixed size, then we only have the left, top pixel
+        # location, not the width and the height. This is set in POINTS3
+        if self._isfixedsize == 1:
+            self._FMT_POINTS2 = FMT[self._version].POINTS3
+        else:
+            self._FMT_POINTS2 = FMT[self._version].POINTS2
+        self._points2_sz = struct.calcsize(self._FMT_POINTS2)
+        # the fixed size is the max_width and max_height parameters
+        self._w = max_width
+        self._h = max_height
+
+    def _read_frame_chunk(self,isbackcompat=False):
+        """read frame chunk from just after chunk_id byte
+
+        start_location is the file locate at which the chunk started
+        (i.e. curpos-1)
+        """
+        intup = struct.unpack(FMT[self._version].POINTS1,
+                              self._fd_read(self._points1_sz))
+        timestamp, n_pts = intup
+
+        regions = []
+
+        # read the fixed size data
+        if self._isfixedsize == 1:
+
+            # for quicker reading and writing, the data here is stored as
+            # all x-locations, followed by all y-locations, followed by
+            # all pixel values.
+            lenbuf = n_pts*self._points2_sz
+            buf = self._fd_read(lenbuf)
+            locs = np.fromstring(buf,dtype=np.uint16)
+            locs.shape = (2,n_pts)
+            # the pixel values are indexed by box number, followed by
+            # column, followed by row, followed by color
+            lenbuf = n_pts*self._w*self._h*self._bytesperpixel
+            buf = self._fd_read(lenbuf)
+            im = np.fromstring(buf,dtype=np.uint8)
+            im.shape = (self._bytesperpixel,self._h,self._w,n_pts)
+            im = im.transpose(1,2,0,3)
+            # if we need regions to be backwards compatible, we
+            # compute in the standard way
+            if isbackcompat:
+                for ptno in range(n_pts):
+                    regions.append((locs[0,ptno],locs[1,ptno],im[:,:,:,ptno]))
+            else:
+                # otherwise, regions is just the pair of locations and
+                # image data
+                regions = (locs,im)
+        else:
+            for ptno in range(n_pts):
+                intup = struct.unpack(self._FMT_POINTS2,
+                                      self._fd_read(self._points2_sz))
+                (xmin, ymin, w, h) = intup
+                # read in RGB24 data
+                # the data is indexed by column, then row, then color
+                # colors are in the order RGB.
+                if self._coding == 'rgb24':
+                    lenbuf = w*h*self._bytesperpixel
+                    buf = self._fd_read(lenbuf)
+                    im = np.fromstring(buf,dtype=np.uint8)
+                    im.shape = (self._bytesperpixel,h,w)
+                    im = im.transpose((1,2,0))
+                elif self._coding == 'mono8':
+                    lenbuf = w*h
+                    buf = self._fd_read(lenbuf)
+                    im = np.fromstring(buf,dtype=np.uint8)
+                    im.shape = (h,w)
+                else:
+                    raise NotImplementedError('Color coding %s not yet implemented'%self._coding)
+                regions.append( (xmin,ymin,im) )
+        return timestamp,regions
+
+
+
+class _UFmfV3Indexer(object):
+    """create an index from an un-unindexed .ufmf v3 file"""
+    def __init__(self,fd, version,
+                 ignore_preexisting_index=False,
+                 short_file_ok=False,
+                 index_progress=False,
+                 ):
+        self._fd = fd
+        self._version = version
+
+        self._keyframe2_sz = struct.calcsize(FMT[self._version].KEYFRAME2)
+        self._points1_sz = struct.calcsize(FMT[self._version].POINTS1)
+        self._points2_sz = struct.calcsize(FMT[self._version].POINTS2)
+
+        self.r = _UFmfV3LowLevelReader(self._fd, self._version)
+        self._short_file_ok = short_file_ok
+        self._index_chunk_location = None
+        self._ignore_preexisting_index = ignore_preexisting_index
+        self._index_progress = index_progress
+        self._create_index()
+
+    def get_index(self):
+        result = {'frame':self._index['frame']}
+        # remove defaultdict and convert to dict
+        result['keyframe'] = {}
+        for keyframe_type,value in self._index['keyframe'].iteritems():
+            result['keyframe'][keyframe_type] = value
+        return result
+
+    def get_expected_index_chunk_location(self):
+        return self._index_chunk_location
+
+    def _create_index(self):
+        self._index = {'keyframe':collections.defaultdict(dict),
+                       'frame':dict(timestamp=[],
+                                    loc=[])}
+        if self._index_progress:
+            import progressbar
+
+            widgets=['indexing: ', progressbar.Percentage(), ' ',
+                     progressbar.Bar(), ' ', progressbar.ETA()]
+            cur_pos = self._fd.tell()
+            # find file size (use seek not stat because we may not know name)
+            try:
+                self._fd.seek(0,os.SEEK_END) # last byte
+                final_pos = self._fd.tell()
+            finally:
+                self._fd.seek(cur_pos)
+            pbar=progressbar.ProgressBar(widgets=widgets,maxval=final_pos).start()
+        while 1:
+            if self._index_progress:
+                pbar.update(self._fd.tell())
+            chunk_id, result = self._index_next_chunk()
+            if chunk_id is None:
+                break # no more frames
+        if self._index_progress:
+            pbar.finish()
+        # convert to arrays
+        for keyframe_type in self._index['keyframe'].keys():
+            for key in self._index['keyframe'][keyframe_type].keys():
+                self._index['keyframe'][keyframe_type][key]=np.array(
+                    self._index['keyframe'][keyframe_type][key])
+        for key in self._index['frame'].keys():
+            self._index['frame'][key]=np.array(
+                self._index['frame'][key])
+        if self._index_chunk_location is None:
+            self._index_chunk_location = self._fd.tell()
+
+    def _index_next_chunk(self):
+        loc = self._fd.tell()
+        chunk_id_str = self.r._fd_read(1,short_OK=True)
+        if chunk_id_str == '':
+            return None, None
+        chunk_id = ord(chunk_id_str)
+        try:
+            if chunk_id==KEYFRAME_CHUNK:
+                result = self.r._read_keyframe_chunk()
+                keyframe_type,frame,timestamp=result
+                tmp = self._index['keyframe'][keyframe_type]
+                if len(tmp)==0:
+                    tmp['timestamp']=[]
+                    tmp['loc']=[]
+                tmp['timestamp'].append(timestamp)
+                tmp['loc'].append(loc)
+            elif chunk_id==FRAME_CHUNK:
+                # read frame chunk
+                result = self.r._read_frame_chunk()
+                timestamp,regions = result
+                tmp = self._index['frame']
+                tmp['timestamp'].append(timestamp)
+                tmp['loc'].append(loc)
+            elif chunk_id==INDEX_DICT_CHUNK:
+                if not self._ignore_preexisting_index:
+                    raise PreexistingIndexExists('indexer encountered index',
+                                                 loc=loc)
+                else:
+                    self.r._fd.seek(-1,os.SEEK_CUR) # undo chunk read - go back
+                    return None,None
+            else:
+                raise ValueError('unexpected byte %d where chunk ID expected'%(
+                    chunk_id,))
+        except ShortUFMFFileError:
+            if self._short_file_ok:
+                self._index_chunk_location = loc
+                return None,None
+            else:
+                raise
+        return chunk_id, result
+
+class PreexistingIndexExists(Exception):
+    def __init__(self,mystr,loc=None):
+        super(PreexistingIndexExists,self).__init__(mystr)
+        self.loc = loc
+
+class UfmfV3(UfmfBase):
+    """class to read .ufmf version 3 files"""
+    def _get_interface_version(self):
+        return 3
+
+    def __init__(self,file,
+                 mode='rb',
+                 ignore_preexisting_index=False,
+                 is_ok_to_write_regenerated_index=True,
+                 short_file_ok=False,
+                 raise_write_errors=False,
+                 index_progress=False,
+                 ):
+        """
+        **Arguments**
+        file : file name or file object
+            The file with the .ufmf data to read
+
+        **Optional keyword arguments**
+        mode : string
+            The mode to open the file with (e.g. 'rb' for read only, binary)
+        ignore_preexisting_index : boolean
+            Whether to ignore the index generate a new one
+        is_ok_to_write_regenerated_index : boolean
+            Whether to write index to disk if regenerated
+        short_file_ok : boolean
+            Whether to ignore short file errors
+        raise_write_errors : boolean
+            Whether to ignore short file errors
+        index_progress : boolean
+            Whether to display a text-based progressbar while indexing
+        """
+        super(UfmfV3,self).__init__()
+        if hasattr(file,'read'):
+            # file-like object
+            self._file_opened=False
+            self._fd = file
+        else:
+            # filename
+            stat_result = os.stat(file)
+            self._fd = open(file,mode=mode)
+            self._file_opened=True
+
+        expected_version = self._get_interface_version()
+        self._r = _UFmfV3LowLevelReader(self._fd,expected_version)
+
+        bufsz = struct.calcsize(FMT[expected_version].HEADER)
+        buf = self._r._fd_read( bufsz )
+        intup = struct.unpack(FMT[expected_version].HEADER, buf)
+        (ufmf_str, self._version, index_location,
+         self._max_width, self._max_height,
+         coding_str_len) = intup
+
+        assert ufmf_str=='ufmf'
+        assert expected_version==self._version
+        self._coding = self._r._fd_read( coding_str_len )
+        self._coding = self._coding.lower()
+
+        # store the coding in the low-level reader
+        self._r.set_coding(self._coding)
+
+        self._next_frame = 0
+        if ignore_preexisting_index:
+            index_location = 0
+
+        self._keyframe2_sz = struct.calcsize(FMT[self._version].KEYFRAME2)
+        self._points1_sz = struct.calcsize(FMT[self._version].POINTS1)
+        self._points2_sz = struct.calcsize(FMT[self._version].POINTS2)
+
+        if index_location == 0:
+            # no pre-existing index. generate it.
+            # save it.
+            tmp = _UFmfV3Indexer(
+                self._fd, self._version,
+                ignore_preexisting_index=ignore_preexisting_index,
+                short_file_ok=short_file_ok,
+                index_progress=index_progress,
+                )
+            self._index = tmp.get_index()
+            if not is_ok_to_write_regenerated_index:
+                return
+            loc = tmp.get_expected_index_chunk_location()
+            self._fd.seek(loc)
+            try:
+                index_dict_location = self._fd.tell()+1 # not the chunk location - add one
+                if self._version==2 and index_dict_location > 4294967295:
+                    raise ValueError('index location will not fit in .ufmf v2 file')
+
+                b = chr(INDEX_DICT_CHUNK)
+                self._fd.write(b)
+                _write_dict( self._fd, self._index )
+                self._fd.truncate()
+                self._fd.seek(0)
+                buf = struct.pack( FMT[self._version].HEADER, 'ufmf',
+                                   self._version, index_dict_location,
+                                   self._max_width, self._max_height,
+                                   len(self._coding) )
+                self._fd.write(buf)
+            except IOError, err:
+                if raise_write_errors:
+                    raise
+                else:
+                    warnings.warn('IO error when trying to save .ufmf index '
+                                  'for %s (was .ufmf file opened read-only?)'%(
+                        file,))
+        else:
+            # we are already in the chunk, so we don't expect INDEX_DICT_CHUNK
+            # read index
+            self._seek(index_location)
+            buf = self._fd.read(4096)
+
+            # next char is 'd' for dict
+            id = buf[:1]
+            buf = buf[1:]
+            try:
+                assert id=='d' # dictionary
+
+                self._index,buf_remaining = _read_dict(self._fd, buf_remaining=buf)
+                if len(buf_remaining)!=0:
+                    raise ValueError('bytes after expected end of file')
+            except:
+                raise CorruptIndexError('the .ufmf index is corrupt. '
+                                        '(Hint: Try the ufmf_reindex command.)')
+
+    def get_index(self):
+        return self._index
+
+    def get_keyframe_for_timestamp(self, keyframe_type, timestamp):
+        """return the most recent keyframe before or at the time of timestamp"""
+        ts = self._index['keyframe'][keyframe_type]['timestamp']
+        cond = timestamp >= ts
+        idxs = np.nonzero(cond)[0]
+        if len(idxs)==0:
+            raise NoMoreFramesException('no keyframe_type %s prior to %s'%(
+                keyframe_type,repr(timestamp)))
+        idx = idxs[-1]
+        return self._get_keyframe_N(keyframe_type,idx)
+
+    def get_number_of_frames(self):
+        """return the number of frames"""
+        return len(self._index['frame']['loc'])
+
+    def get_max_size(self):
+        return (self._max_width, self._max_height)
+
+    def get_coding(self):
+        return self._coding
+
+    def get_progress(self):
+        locs = self._index['frame']['loc']
+        return float(self._next_frame)/len(locs)
+
+    def set_next_frame(self,fno):
+        self._next_frame = fno
+
+    def readframes(self):
+        locs = self._index['frame']['loc']
+        while self._next_frame < len(locs):
+            loc = locs[self._next_frame]
+            self._next_frame += 1
+
+            self._seek(loc+1)
+            result = self._r._read_frame_chunk()
+            timestamp,regions = result
+            yield timestamp,regions
+
+    def _get_keyframe_N(self, keyframe_type, N):
+        """get Nth keyframe of type keyframe_type"""
+        try:
+            tmp = self._index['keyframe'][keyframe_type]
+        except KeyError:
+            raise NoMoreFramesException('no keyframe_type %s'%keyframe_type)
+        loc = tmp['loc'][N]
+        timestamp = tmp['timestamp'][N]
+
+        self._seek(loc+1)
+        result = self._r._read_keyframe_chunk()
+        test_keyframe_type,frame,test_timestamp=result
+        assert keyframe_type==test_keyframe_type
+        assert timestamp==test_timestamp
+        return frame,timestamp
+
+    def _seek(self,loc):
+        self._fd.seek(loc,0)
+
+    def get_bg_image(self):
+        """return the first raw image (for compatability with UfmfV1)"""
+        return self._get_keyframe_N('frame0',0)
+
+    def close(self):
+        if self._file_opened:
+            self._fd.close()
+            self._file_opened = False
+
+# added by KB:
+# UfmfV4 is the same as V3 except the header contains an extra
+# field. This field is a uint8 and is 1 if all the boxes are
+# fixed at size max_height, max_width, and 0 if the standard,
+# variable-size boxes are used.
+class UfmfV4(UfmfV3):
+    def _get_interface_version(self):
+        return 4
+
+    def __init__(self,file,
+                 mode='rb',
+                 ignore_preexisting_index=False,
+                 is_ok_to_write_regenerated_index=True,
+                 short_file_ok=False,
+                 raise_write_errors=False,
+                 index_progress=False,
+                 ):
+        """
+        **Arguments**
+        file : file name or file object
+            The file with the .ufmf data to read
+
+        **Optional keyword arguments**
+        mode : string
+            The mode to open the file with (e.g. 'rb' for read only, binary)
+        ignore_preexisting_index : boolean
+            Whether to ignore the index generate a new one
+        is_ok_to_write_regenerated_index : boolean
+            Whether to write index to disk if regenerated
+        short_file_ok : boolean
+            Whether to ignore short file errors
+        raise_write_errors : boolean
+            Whether to ignore short file errors
+        index_progress : boolean
+            Whether to display a text-based progressbar while indexing
+        """
+        super(UfmfV3,self).__init__()
+        if hasattr(file,'read'):
+            # file-like object
+            self._file_opened=False
+            self._fd = file
+        else:
+            # filename
+            stat_result = os.stat(file)
+            self._fd = open(file,mode=mode)
+            self._file_opened=True
+
+        expected_version = self._get_interface_version()
+        # V4: use V4 low-level reader
+        self._r = _UFmfV4LowLevelReader(self._fd,expected_version)
+
+        bufsz = struct.calcsize(FMT[expected_version].HEADER)
+        buf = self._r._fd_read( bufsz )
+        intup = struct.unpack(FMT[expected_version].HEADER, buf)
+        # V4: set isfixedsize to 1 if all boxes will be the same size
+        # and the width and height are not being stored for each box
+        (ufmf_str, self._version, index_location,
+         self._max_width, self._max_height, self._isfixedsize,
+         coding_str_len) = intup
+        # store the new parameters in V4
+        self._r.set_params(self._max_width,self._max_height,self._isfixedsize)
+
+        assert ufmf_str=='ufmf'
+        assert expected_version==self._version
+        self._coding = self._r._fd_read( coding_str_len )
+        self._coding = self._coding.lower()
+
+        # store the coding in the low-level reader
+        self._r.set_coding(self._coding)
+
+        self._next_frame = 0
+        if ignore_preexisting_index:
+            index_location = 0
+
+        self._keyframe2_sz = struct.calcsize(FMT[self._version].KEYFRAME2)
+        self._points1_sz = struct.calcsize(FMT[self._version].POINTS1)
+        self._points2_sz = struct.calcsize(FMT[self._version].POINTS2)
+        # V4: POINTS3 corresponds to fixed size boxes, POINTS2 variable
+        self._points3_sz = struct.calcsize(FMT[self._version].POINTS3)
+
+        if index_location == 0:
+            # no pre-existing index. generate it.
+            # save it.
+            # just using V3 indexer. is this okay?
+            tmp = _UFmfV3Indexer(
+                self._fd, self._version,
+                ignore_preexisting_index=ignore_preexisting_index,
+                short_file_ok=short_file_ok,
+                index_progress=index_progress,
+                )
+            self._index = tmp.get_index()
+            if not is_ok_to_write_regenerated_index:
+                return
+            loc = tmp.get_expected_index_chunk_location()
+            self._fd.seek(loc)
+            try:
+                index_dict_location = self._fd.tell()+1 # not the chunk location - add one
+                if self._version==2 and index_dict_location > 4294967295:
+                    raise ValueError('index location will not fit in .ufmf v2 file')
+
+                b = chr(INDEX_DICT_CHUNK)
+                self._fd.write(b)
+                _write_dict( self._fd, self._index )
+                self._fd.truncate()
+                self._fd.seek(0)
+                # V4: include isfixedsize in buf
+                buf = struct.pack( FMT[self._version].HEADER, 'ufmf',
+                                   self._version, index_dict_location,
+                                   self._max_width, self._max_height,
+                                   self._isfixedsize,
+                                   len(self._coding) )
+                self._fd.write(buf)
+            except IOError, err:
+                if raise_write_errors:
+                    raise
+                else:
+                    warnings.warn('IO error when trying to save .ufmf index '
+                                  'for %s (was .ufmf file opened read-only?)'%(
+                        file,))
+        else:
+            # we are already in the chunk, so we don't expect INDEX_DICT_CHUNK
+            # read index
+            self._seek(index_location)
+            buf = self._fd.read(4096)
+
+            # next char is 'd' for dict
+            id = buf[:1]
+            buf = buf[1:]
+            try:
+                assert id=='d' # dictionary
+
+                self._index,buf_remaining = _read_dict(self._fd, buf_remaining=buf)
+                if len(buf_remaining)!=0:
+                    raise ValueError('bytes after expected end of file')
+            except:
+                raise CorruptIndexError('the .ufmf index is corrupt. '
+                                        '(Hint: Try the ufmf_reindex command.)')
+
+
+
+class UfmfV2(UfmfV3):
+    """class to read .ufmf version 2 files"""
+    def _get_interface_version(self):
+        return 2
+
+class NoSuchFrameError(IndexError):
+    pass
+
+def md5sum_headtail(filename):
+    """quickly calculate a hash value for an even giant file"""
+    fd = open(filename,mode='rb')
+    start_bytes = fd.read(1000)
+
+    try:
+        fd.seek(-1000,os.SEEK_END)
+    except IOError,err:
+        # it's OK, we'll just read up to another 1000 bytes
+        pass
+
+    stop_bytes = fd.read(1000)
+    bytes = start_bytes+stop_bytes
+    m = hashlib.md5()
+    m.update(bytes)
+    return m.digest()
+
+class FlyMovieEmulator(object):
+    def __init__(self,filename,
+                 darken=0,
+                 allow_no_such_frame_errors=False,
+                 white_background=False,
+                 abs_diff=False,
+                 **kwargs):
+        self._ufmf = Ufmf(
+            filename,**kwargs)
+        self._last_frame = None
+        self.filename = filename
+        try:
+            self._bg0,self._ts0=self._ufmf.get_bg_image()
+        except NoMoreFramesException:
+            pass
+        self._darken=darken
+        self._allow_no_such_frame_errors = allow_no_such_frame_errors
+        self._timestamps = None
+        if isinstance(self._ufmf,UfmfV1):
+            self.format = 'MONO8' # by definition
+            self._fno2loc = None
+            if self._ufmf.use_conventional_named_mean_fmf:
+                assert white_background==False
+        self.white_background = white_background
+        self.abs_diff = abs_diff
+        if self.abs_diff:
+            if not (isinstance(self._ufmf,UfmfV1) and
+                    self._ufmf.use_conventional_named_mean_fmf):
+                raise NotImplementedError('abs_diff currently requires UfmfV1 '
+                                          'and use_conventional_named_mean_fmf')
+        if isinstance(self._ufmf,UfmfV4) and self._ufmf._isfixedsize:
+            self._isfixedsize = True
+        else:
+            self._isfixedsize = False
+
+
+    def close(self):
+        self._ufmf.close()
+
+    def get_n_frames(self):
+        if isinstance(self._ufmf,UfmfV1):
+            self._fill_timestamps_and_locs()
+            last_frame = len(self._fno2loc)
+            return last_frame+1
+        else:
+            return self._ufmf.get_number_of_frames()
+
+    def get_format(self):
+        if isinstance(self._ufmf,UfmfV1):
+            return self.format
+        else:
+            return self._ufmf.get_coding()
+
+    def get_bits_per_pixel(self):
+        return 8
+    def get_all_timestamps(self):
+        self._fill_timestamps_and_locs()
+        return self._timestamps
+    def get_frame(self,fno,allow_partial_frames=False,_return_more=False):
+        if allow_partial_frames:
+            warnings.warn('unsupported argument "allow_partial_frames" ignored')
+        try:
+            self.seek(fno)
+        except NoSuchFrameError, err:
+            if self._allow_no_such_frame_errors:
+                raise
+            else:
+                return self._bg0,self._ts0 # just return first background image
+        else:
+            return self.get_next_frame(_return_more=_return_more)
+
+    def seek(self,fno):
+        if isinstance(self._ufmf,UfmfV1):
+            if 0<= fno < len(self._fno2loc):
+                loc = self._fno2loc[fno]
+                self._ufmf.seek(loc)
+                self._last_frame = None
+            else:
+                raise NoSuchFrameError('fno %d not in .ufmf file'%fno)
+        else:
+            self._ufmf.set_next_frame( fno )
+
+    def get_mean_for_timestamp(self, timestamp):
+        if isinstance(self._ufmf,UfmfV1):
+            return self._ufmf.get_mean_for_timestamp( timestamp )
+        else:
+            mean_im, tmp_timestamp = self._ufmf.get_keyframe_for_timestamp(
+                'mean', timestamp )
+            return mean_im
+
+    def get_next_frame(self, _return_more=False):
+        have_frame = False
+        more = {}
+        for timestamp, regions in self._ufmf.readframes():
+            if isinstance(self._ufmf,UfmfV1):
+                if self._ufmf.use_conventional_named_mean_fmf:
+                    tmp=self._ufmf.get_mean_for_timestamp(timestamp,
+                                                          _return_more=_return_more)
+                    if _return_more:
+                        mean_image, sumsqf_image = tmp
+                        more['sumsqf'] = sumsqf_image
+                    else:
+                        mean_image = tmp
+                    self._last_frame = np.array(mean_image,copy=True).astype(np.uint8)
+                    more['mean'] = mean_image
+                elif self.white_background:
+                    self._last_frame = numpy.empty(self._bg0.shape,dtype=np.uint8)
+                    self._last_frame.fill(255)
+                else:
+                    if self._last_frame is None:
+                        self._last_frame = numpy.array(self._bg0,copy=True)
+            else:
+                try:
+                    mean_image,im_timestamp=self._ufmf.get_keyframe_for_timestamp('mean',timestamp)
+                except (KeyError, NoMoreFramesException):
+                    warnings.warn('UfmfV3 fmf emulator filling bg with white')
+                    w,h=self._ufmf.get_max_size()
+                    mean_image = numpy.empty((h,w),dtype=np.uint8)
+                    mean_image.fill(255)
+                if _return_more:
+                    sumsqf_image,sq_timestamp=self._ufmf.get_keyframe_for_timestamp('sumsq',timestamp)
+                    more['sumsqf'] = sumsqf_image
+                if not self.white_background:
+                    self._last_frame = np.array(mean_image,copy=True).astype(np.uint8)
+                else:
+                    self._last_frame = np.empty(mean_image.shape,dtype=np.uint8)
+                    self._last_frame.fill(255)
+                more['mean'] = mean_image
+            have_frame = True
+            more['regions'] = regions
+            if self._isfixedsize:
+                locs,im = regions
+                h,w,ncolors,npts = im.shape
+                if self._last_frame.ndim == 2:
+                    im = im.reshape(h,w,npts)
+                if h == 1 and w == 1:
+                    if self._last_frame.ndim == 3:
+                        self._last_frame[locs[1,:],locs[0,:],:] = np.reshape(im,(ncolors,npts)).T
+                    else:
+                        self._last_frame[locs[1,:],locs[0,:]] = np.reshape(im,(npts,))
+                else:
+                    if self._last_frame.ndim == 3:
+                        for ptno in range(npts):
+                            self._last_frame[locs[1,ptno]:(locs[1,ptno]+h),
+                                             locs[0,ptno]:(locs[0,ptno]+w),:] = \
+                                             im[:,:,:,ptno]
+                    else:
+                        for ptno in range(npts):
+                            self._last_frame[locs[1,ptno]:(locs[1,ptno]+h),
+                                             locs[0,ptno]:(locs[0,ptno]+w)] = \
+                                             im[:,:,ptno]
+
+            else:
+                for xmin,ymin,bufim in regions:
+                    if bufim.ndim == 3:
+                        h,w,ncolors=bufim.shape
+                        tmp = self._last_frame[ymin:ymin+h, xmin:xmin+w, :]
+                        self._last_frame[ymin:ymin+h, xmin:xmin+w, :]=\
+                            np.clip(bufim-self._darken, 0,255)
+                    elif bufim.ndim == 2:
+                        h,w=bufim.shape
+                        self._last_frame[ymin:ymin+h, xmin:xmin+w]=\
+                            np.clip(bufim-self._darken, 0,255)
+                    else:
+                        raise NotImplementedError('bufim.ndim = %d not implemented'%bufim.ndim)
+            if self.abs_diff:
+                self._last_frame=abs(self._last_frame.astype(np.float32)-
+                                     mean_image.astype(np.float32))
+                self._last_frame = np.clip(self._last_frame,0,255).astype(np.uint8)
+            break # only want 1 frame
+        if not have_frame:
+            raise NoMoreFramesException('EOF')
+        if _return_more:
+            return self._last_frame, timestamp, more
+        else:
+            return self._last_frame, timestamp
+
+    def _fill_timestamps_and_locs(self):
+        if self._timestamps is not None:
+            # already did this
+            return
+
+        if isinstance(self._ufmf,UfmfV3):
+            index = self._ufmf.get_index()
+            self._timestamps = index['frame']['timestamp']
+            return
+
+        assert isinstance(self._ufmf,UfmfV1)
+
+        src_dir, fname = os.path.split(os.path.abspath( self.filename ))
+        cache_dir = os.path.join( src_dir, '.ufmf-cache' )
+        fname_base = os.path.splitext(fname)[0]
+        cache_fname = os.path.join( cache_dir, fname_base+'.cache.npz' )
+        try:
+            if not os.path.exists(cache_dir):
+                os.mkdir(cache_dir)
+
+            my_hash = md5sum_headtail(self.filename)
+            assert self._fno2loc is None
+
+            # load results from hash file
+            if os.path.exists(cache_fname):
+                npz = np.load(cache_fname)
+                cache_hash = str(npz['my_hash'])
+                if cache_hash==my_hash:
+                    self._timestamps = npz['timestamps']
+                    self._fno2loc = npz['fno2loc']
+                    return
+        except Exception, err:
+            if int(os.environ.get('UFMF_FORCE_CACHE','0')):
+                raise
+            else:
+                warnings.warn( 'While attempting to open cache in %s: %s '
+                               ' (set environment variable '
+                               'UFMF_FORCE_CACHE=1 to raise)'%(cache_fname,err))
+
+        # no hash file or stale hash file -- recompute
+
+        self._timestamps = []
+        self._fno2loc = []
+        start_pos = self._ufmf.tell()
+        self._fno2loc.append( start_pos )
+        for timestamp, regions in self._ufmf.readframes():
+            self._timestamps.append( timestamp )
+            self._fno2loc.append( self._ufmf.tell() )
+        del self._fno2loc[-1] # remove last entry -- it's at end of file
+        self._ufmf.seek( start_pos )
+
+        assert len(self._timestamps)==len(self._fno2loc)
+
+        try:
+            # save results to hash file
+            timestamps = np.array(self._timestamps)
+            fno2loc = np.array(self._fno2loc)
+            np.savez(cache_fname,
+                     my_hash=my_hash,
+                     timestamps=timestamps,
+                     fno2loc=fno2loc)
+        except Exception,err:
+            if int(os.environ.get('UFMF_FORCE_CACHE','0')):
+                raise
+            else:
+                warnings.warn( str(err)+' (set environment variable '
+                               'UFMF_FORCE_CACHE=1 to raise)' )
+
+    def get_height(self):
+        if isinstance(self._ufmf,UfmfV1):
+            return self._bg0.shape[0]
+        else:
+            return self._ufmf.get_max_size()[1]
+
+    def get_width(self):
+        if isinstance(self._ufmf,UfmfV1):
+            return self._bg0.shape[1]
+        else:
+            return self._ufmf.get_max_size()[0]
+
+def UfmfSaver( file,
+               frame0=None,
+               timestamp0=None,
+               **kwargs):
+    """factory function to return UfmfSaverBase instance"""
+    default_version = 3
+    version = kwargs.pop('version',default_version)
+    if version is None:
+        version = default_version
+
+    if version==1:
+        return UfmfSaverV1(file,frame0,timestamp0,**kwargs)
+    elif version==2:
+        return UfmfSaverV2(file,frame0=frame0,timestamp0=timestamp0,**kwargs)
+    elif version==3:
+        return UfmfSaverV3(file,frame0=frame0,timestamp0=timestamp0,**kwargs)
+    else:
+        raise ValueError('unknown version %s'%version)
+
+class UfmfSaverBase(object):
+    def __init__(self,version):
+        self.version = version
+
+class UfmfSaverV1(UfmfSaverBase):
+    """class to write (save) .ufmf v1 files"""
+    def __init__(self,
+                 filename,
+                 frame0,
+                 timestamp0,
+                 image_radius=10,
+                 ):
+        super(UfmfSaverV1,self).__init__(1)
+        self.filename = filename
+        mode = "w+b"
+        self.file = open(self.filename,mode=mode)
+        self.image_radius = image_radius
+
+        bg_frame = numpy.asarray(frame0)
+        self.height, self.width = bg_frame.shape
+        assert bg_frame.dtype == numpy.uint8
+        self.timestamp0 = timestamp0
+
+        self.file.write(struct.pack(FMT[1].HEADER,
+                                    self.version, self.image_radius,
+                                    self.timestamp0,
+                                    self.width, self.height))
+        bg_data = bg_frame.tostring()
+        assert len(bg_data)==self.height*self.width
+        self.file.write(bg_data)
+        self.last_timestamp = self.timestamp0
+
+    def add_frame(self,origframe,timestamp,point_data):
+        origframe = numpy.asarray( origframe )
+
+        assert origframe.shape == (self.height, self.width)
+
+        n_pts = len(point_data)
+        self.file.write(struct.pack(FMT[1].CHUNKHEADER, timestamp, n_pts ))
+        str_buf = []
+        for this_point_data in point_data:
+            xidx, yidx = this_point_data[:2]
+
+            xmin = int(round(xidx-self.image_radius))
+            xmin = max(0,xmin)
+
+            xmax = xmin + 2*self.image_radius
+            xmax = min( xmax, self.width)
+            if xmax == self.width:
+                xmin = self.width - (2*self.image_radius)
+
+            ymin = int(round(yidx-self.image_radius))
+            ymin = max(0,ymin)
+
+            ymax = ymin + 2*self.image_radius
+            ymax = min( ymax, self.height)
+            if ymax == self.height:
+                ymin = self.height - (2*self.image_radius)
+
+            assert ymax-ymin == (2*self.image_radius)
+            assert xmax-xmin == (2*self.image_radius)
+
+            roi = origframe[ ymin:ymax, xmin:xmax ]
+            this_str_buf = roi.tostring()
+            this_str_head = struct.pack(FMT[1].SUBHEADER, xmin, ymin)
+
+            str_buf.append( this_str_head + this_str_buf )
+        fullstr = ''.join(str_buf)
+        if len(fullstr):
+            self.file.write(fullstr)
+        self.last_timestamp = timestamp
+
+    def close(self):
+        self.file.close()
+
+    def __del__(self):
+        if hasattr(self,'file'):
+            self.close()
+
+class UfmfSaverV3(UfmfSaverBase):
+    """class to write (save) .ufmf v3 files"""
+    def _get_interface_version(self):
+        return 3
+
+    def __init__(self, file,
+                 coding='MONO8',
+                 frame0=None,
+                 timestamp0=None,
+                 max_width=None,
+                 max_height=None,
+                 xinc_yinc=None,
+                 ):
+        super(UfmfSaverV3,self).__init__(self._get_interface_version())
+        if hasattr(file,'write'):
+            # file-like object
+            self.file = file
+            self._file_opened = False
+        else:
+            self.file = open(file,mode="w+b")
+            self._file_opened = True
+        self.coding = coding
+        if max_width is None or max_height is None:
+            raise ValueError('max_width and max_height must be set')
+        self.max_width=max_width
+        self.max_height=max_height
+        buf = struct.pack( FMT[self.version].HEADER, 'ufmf',
+                           self.version, 0, self.max_width, self.max_height,
+                           len(self.coding) )
+        self.file.write(buf)
+        self.file.write(coding)
+        if xinc_yinc is None:
+            if coding=='MONO8':
+                xinc_yinc = (2,2)
+            elif coding.startswith('MONO8:'):
+                # Bayer pattern
+                xinc_yinc = (2,2)
+            elif coding=='YUV422':
+                xinc_yinc = (4,1)
+            else:
+                warnings.warn('ufmf xinc_yinc set (2,2) because coding unknown')
+                xinc_yinc = (2,2)
+        self.xinc, self.yinc = xinc_yinc
+        self._index = {'keyframe':collections.defaultdict(dict),
+                       'frame':{}}
+        if frame0 is not None or timestamp0 is not None:
+            self.add_keyframe('frame0',frame0,timestamp0)
+
+        self.min_bytes = struct.calcsize(FMT[self.version].POINTS2)
+
+    def add_keyframe(self,keyframe_type,image_data,timestamp):
+        char2 = len(keyframe_type)
+        np_image_data = numpy.asarray(image_data)
+        if np_image_data.dtype == np.uint8:
+            dtype = 'B'
+            strides1=1
+        elif np_image_data.dtype == np.float32:
+            dtype = 'f'
+            strides1=4
+        else:
+            raise ValueError('dtype %s not supported'%image_data.dtype)
+        assert np_image_data.ndim == 2
+        height, width = np_image_data.shape
+        try:
+            assert np_image_data.strides[0] == width*np_image_data.strides[1]
+            assert np_image_data.strides[1] == strides1
+        except:
+            print 'np_image_data.strides, width',np_image_data.strides, width
+            raise
+        b =  chr(KEYFRAME_CHUNK) + chr(char2) + keyframe_type # chunkid, len(type), type
+        b += struct.pack(FMT[self.version].KEYFRAME2,dtype,width,height,timestamp)
+        loc = self.file.tell()
+        tmp = self._index['keyframe'][keyframe_type]
+        if len(tmp)==0:
+            tmp['timestamp']=[]
+            tmp['loc']=[]
+        tmp['timestamp'].append(timestamp)
+        tmp['loc'].append(loc)
+        self.file.write(b)
+        self.file.write(buffer(np_image_data))
+
+    def _add_frame_regions(self,timestamp,regions):
+        n_pts = len(regions)
+        b = chr(FRAME_CHUNK) + struct.pack(FMT[self.version].POINTS1, timestamp, n_pts)
+        loc = self.file.tell()
+        tmp = self._index['frame']
+        if len(tmp)==0:
+            tmp['timestamp']=[]
+            tmp['loc']=[]
+        tmp['timestamp'].append(timestamp)
+        tmp['loc'].append(loc)
+        self.file.write(b)
+        str_buf = []
+        for region in regions:
+            xmin,ymin,roi = region
+            h,w = roi.shape
+            this_str_buf = roi.tostring()
+            assert len(this_str_buf)==w*h
+            this_str_head = struct.pack(FMT[self.version].POINTS2, xmin, ymin, w, h)
+            str_buf.append( this_str_head + this_str_buf )
+        fullstr = ''.join(str_buf)
+        self.file.write(fullstr)
+
+    def add_frame(self,origframe,timestamp,point_data):
+        origframe = np.asarray(origframe)
+        origframe_h, origframe_w = origframe.shape
+        rects = []
+        regions = []
+        if len(point_data):
+            for this_point_data in point_data:
+                xidx, yidx, w, h = this_point_data[:4]
+                w_radius = w//2
+                h_radius = h//2
+
+                xmin = int(round(xidx-w_radius)//self.xinc*self.xinc) # keep 2x2 Bayer
+                xmin = max(0,xmin)
+
+                xmax = xmin + w
+                newxmax = min( xmax, self.max_width, origframe_w)
+                if newxmax != xmax:
+                    #xmin = newxmax - w
+                    w = newxmax - xmin
+                    xmax = newxmax
+
+                ymin = int(round(yidx-h_radius)//self.yinc*self.yinc) # keep 2x2 Bayer
+                ymin = max(0,ymin)
+
+                ymax = ymin + h
+                newymax = min( ymax, self.max_height, origframe_h)
+                if newymax != ymax:
+                    #ymin = newymax - h
+                    h = newymax - ymin
+                    ymax = newymax
+
+                assert ymax-ymin == h
+                assert xmax-xmin == w
+
+                rects.append( (xmin,ymin, xmax,ymax) )
+
+            ## rects = minimize_rectangle_coverage(
+            ##     rects, rectangle_penalty=self.min_bytes )
+
+            for (xmin,ymin,xmax,ymax) in rects:
+                roi = origframe[ ymin:ymax, xmin:xmax ]
+                regions.append( (xmin, ymin, roi) )
+
+        self._add_frame_regions(timestamp,regions)
+        self.last_timestamp = timestamp
+        return rects
+
+    def close(self):
+        b = chr(INDEX_DICT_CHUNK)
+        self.file.write(b)
+        loc = self.file.tell()
+        if self.version==2 and loc > 4294967295:
+            raise ValueError('index location will not fit in .ufmf v2 file')
+        _write_dict(self.file,self._index)
+        self.file.seek(0)
+        buf = struct.pack( FMT[self.version].HEADER, 'ufmf',
+                           self.version, loc,
+                           self.max_width, self.max_height,
+                           len(self.coding) )
+        self.file.write(buf)
+        if self._file_opened:
+            self.file.close()
+            self._file_opened = False
+
+class AutoShrinkUfmfSaverV3(UfmfSaverV3):
+    """class to write (save) .ufmf v3 files without useless keyframes
+
+    Assumes that frames and keyframes will come in temporal order.
+    Does not save keyframes covering intervals in which no frames arrived.
+    """
+    def __init__(self,*args,**kwargs):
+        self._cached_keyframes = {}
+        super(AutoShrinkUfmfSaverV3,self).__init__(*args,**kwargs)
+    def _add_frame_regions(self,timestamp,regions):
+        if len(regions):
+            for kf_type in self._cached_keyframes.keys():
+                kf_image_data, kf_timestamp = self._cached_keyframes[kf_type]
+                super(AutoShrinkUfmfSaverV3,self).add_keyframe( \
+                                          kf_type, kf_image_data, kf_timestamp)
+                del self._cached_keyframes[kf_type]
+        super(AutoShrinkUfmfSaverV3,self)._add_frame_regions(timestamp,regions)
+    def add_keyframe(self,keyframe_type,image_data,timestamp):
+        self._cached_keyframes[keyframe_type] = (image_data,timestamp)
+
+class UfmfSaverV2(UfmfSaverV3):
+    """class to write (save) .ufmf v2 files"""
+    def _get_interface_version(self):
+        return 2

--- a/lazyflow/operators/ioOperators/UfmfParser.py
+++ b/lazyflow/operators/ioOperators/UfmfParser.py
@@ -11,8 +11,7 @@ import numpy
 import numpy as np
 from numpy import nan
 import logging
-
-logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 import time
 
@@ -1471,7 +1470,7 @@ class UfmfSaverV3(UfmfSaverBase):
             assert np_image_data.strides[0] == width*np_image_data.strides[1]
             assert np_image_data.strides[1] == strides1
         except:
-            print 'np_image_data.strides, width',np_image_data.strides, width
+            logger.warn('np_image_data.strides: {}, width: {}'.format(np_image_data.strides, width) )
             raise
         b =  chr(KEYFRAME_CHUNK) + chr(char2) + keyframe_type # chunkid, len(type), type
         b += struct.pack(FMT[self.version].KEYFRAME2,dtype,width,height,timestamp)

--- a/lazyflow/operators/ioOperators/UfmfParser.py
+++ b/lazyflow/operators/ioOperators/UfmfParser.py
@@ -1,3 +1,5 @@
+# This file was copied from the motmot ufmf GitHub repository: https://github.com/motmot/ufmf commit c795ffe369b7e58de69d34926388af33ce71b711
+
 from __future__ import division
 import sys
 import struct, collections

--- a/lazyflow/operators/ioOperators/__init__.py
+++ b/lazyflow/operators/ioOperators/__init__.py
@@ -22,6 +22,8 @@
 from ioOperators import *
 
 # All "Read" operators must come before OpInputDataReader, which uses them.
+from opStreamingMmfReader import *
+from opStreamingUfmfReader import *
 from opNpyFileReader import *
 from opStreamingHdf5Reader import *
 from opRESTfulVolumeReader import *

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -182,17 +182,16 @@ class OpInputDataReader(Operator):
             mmfReader = OpStreamingMmfReader(parent=self)
             mmfReader.FileName.setValue(filePath)
             
-            #return ([mmfReader], mmfReader.Output)
-            
-            # Cache the pages we read
-            page_shape = mmfReader.Output.meta.ideal_blockshape
-            opCache = OpBlockedArrayCache( parent=self )
-            opCache.fixAtCurrent.setValue( False )
-            opCache.innerBlockShape.setValue( page_shape )
-            opCache.outerBlockShape.setValue( page_shape )
-            opCache.Input.connect( mmfReader.Output )
-             
-            return ([mmfReader, opCache], opCache.Output)
+            # Cache the frames we read
+            frameShape = mmfReader.Output.meta.ideal_blockshape
+              
+            mmfCache = OpBlockedArrayCache( parent=self )
+            mmfCache.fixAtCurrent.setValue( False )
+            mmfCache.innerBlockShape.setValue( frameShape )
+            mmfCache.outerBlockShape.setValue( frameShape )
+            mmfCache.Input.connect( mmfReader.Output )
+               
+            return ([mmfReader, mmfCache], mmfCache.Output)
         else :
             return ([], None)
     
@@ -201,7 +200,15 @@ class OpInputDataReader(Operator):
             ufmfReader = OpStreamingUfmfReader(parent=self)
             ufmfReader.FileName.setValue(filePath)
             
-            return ([ufmfReader], ufmfReader.Output)
+            # Cache the frames we read
+            frameShape = ufmfReader.Output.meta.ideal_blockshape
+            ufmfCache = OpBlockedArrayCache( parent=self )
+            ufmfCache.fixAtCurrent.setValue( False )
+            ufmfCache.innerBlockShape.setValue( frameShape )
+            ufmfCache.outerBlockShape.setValue( frameShape )
+            ufmfCache.Input.connect( ufmfReader.Output )
+             
+            return ([ufmfReader, ufmfCache], ufmfCache.Output)
         else :
             return ([], None)
     

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -181,7 +181,10 @@ class OpInputDataReader(Operator):
         if '.mmf' in filePath:
             mmfReader = OpStreamingMmfReader(parent=self)
             mmfReader.FileName.setValue(filePath)
+
+            return ([mmfReader], mmfReader.Output)
             
+            '''
             # Cache the frames we read
             frameShape = mmfReader.Output.meta.ideal_blockshape
               
@@ -190,8 +193,9 @@ class OpInputDataReader(Operator):
             mmfCache.innerBlockShape.setValue( frameShape )
             mmfCache.outerBlockShape.setValue( frameShape )
             mmfCache.Input.connect( mmfReader.Output )
-               
+
             return ([mmfReader, mmfCache], mmfCache.Output)
+            '''
         else :
             return ([], None)
     
@@ -200,8 +204,12 @@ class OpInputDataReader(Operator):
             ufmfReader = OpStreamingUfmfReader(parent=self)
             ufmfReader.FileName.setValue(filePath)
             
+            return ([ufmfReader], ufmfReader.Output)
+            
             # Cache the frames we read
+            '''
             frameShape = ufmfReader.Output.meta.ideal_blockshape
+            
             ufmfCache = OpBlockedArrayCache( parent=self )
             ufmfCache.fixAtCurrent.setValue( False )
             ufmfCache.innerBlockShape.setValue( frameShape )
@@ -209,6 +217,7 @@ class OpInputDataReader(Operator):
             ufmfCache.Input.connect( ufmfReader.Output )
              
             return ([ufmfReader, ufmfCache], ufmfCache.Output)
+            '''
         else :
             return ([], None)
     

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -179,22 +179,18 @@ class OpInputDataReader(Operator):
 
     def _attemptOpenAsMmf(self, filePath):          
         if '.mmf' in filePath:
-            print 'Opening MMF video'
             mmfReader = OpStreamingMmfReader(parent=self)
             mmfReader.FileName.setValue(filePath)
             
-            print "Done reading MMF video"
             return ([mmfReader], mmfReader.Output)
         else :
             return ([], None)
     
     def _attemptOpenAsUfmf(self, filePath):          
         if '.ufmf' in filePath:
-            print 'Opening uFMF video'
             ufmfReader = OpStreamingUfmfReader(parent=self)
             ufmfReader.FileName.setValue(filePath)
             
-            print "Done reading uFMF video"
             return ([ufmfReader], ufmfReader.Output)
         else :
             return ([], None)

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -29,6 +29,9 @@ from lazyflow.operators.ioOperators import OpStackLoader, OpBlockwiseFilesetRead
 from lazyflow.utility.jsonConfig import JsonConfigParser
 from lazyflow.utility.pathHelpers import isUrl
 
+from opStreamingUfmfReader import OpStreamingUfmfReader
+from opStreamingMmfReader import OpStreamingMmfReader
+
 try:
     from lazyflow.operators.ioOperators import OpDvidVolume
     _supports_dvid = True
@@ -53,13 +56,14 @@ class OpInputDataReader(Operator):
     name = "OpInputDataReader"
     category = "Input"
 
+    videoExts = ['ufmf', 'mmf', 'avi']
     h5Exts = ['h5', 'hdf5', 'ilp']
     npyExts = ['npy']
     blockwiseExts = ['json']
     tiledExts = ['json']
     tiffExts = ['tif', 'tiff']
     vigraImpexExts = vigra.impex.listExtensions().split()
-    SupportedExtensions = h5Exts + npyExts + vigraImpexExts + blockwiseExts
+    SupportedExtensions = h5Exts + npyExts + vigraImpexExts + blockwiseExts + videoExts
     if _supports_dvid:
         dvidExts = ['dvidvol']
         SupportedExtensions += dvidExts
@@ -125,7 +129,9 @@ class OpInputDataReader(Operator):
         if self._file is not None:
             self._file.close()
 
-        openFuncs = [ self._attemptOpenAsDvidVolume,
+        openFuncs = [ self._attemptOpenAsUfmf,
+                      self._attemptOpenAsMmf,
+                      self._attemptOpenAsDvidVolume,
                       self._attemptOpenAsTiffStack,
                       self._attemptOpenAsStack,
                       self._attemptOpenAsHdf5,
@@ -170,6 +176,28 @@ class OpInputDataReader(Operator):
 
         # Directly connect our own output to the internal output
         self.Output.connect( self.opInjector.Output )
+
+    def _attemptOpenAsMmf(self, filePath):          
+        if '.mmf' in filePath:
+            print 'Opening MMF video'
+            mmfReader = OpStreamingMmfReader(parent=self)
+            mmfReader.FileName.setValue(filePath)
+            
+            print "Done reading MMF video"
+            return ([mmfReader], mmfReader.Output)
+        else :
+            return ([], None)
+    
+    def _attemptOpenAsUfmf(self, filePath):          
+        if '.ufmf' in filePath:
+            print 'Opening uFMF video'
+            ufmfReader = OpStreamingUfmfReader(parent=self)
+            ufmfReader.FileName.setValue(filePath)
+            
+            print "Done reading uFMF video"
+            return ([ufmfReader], ufmfReader.Output)
+        else :
+            return ([], None)
     
     def _attemptOpenAsTiffStack(self, filePath):
         if not ('*' in filePath or os.path.pathsep in filePath):

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -182,7 +182,17 @@ class OpInputDataReader(Operator):
             mmfReader = OpStreamingMmfReader(parent=self)
             mmfReader.FileName.setValue(filePath)
             
-            return ([mmfReader], mmfReader.Output)
+            #return ([mmfReader], mmfReader.Output)
+            
+            # Cache the pages we read
+            page_shape = mmfReader.Output.meta.ideal_blockshape
+            opCache = OpBlockedArrayCache( parent=self )
+            opCache.fixAtCurrent.setValue( False )
+            opCache.innerBlockShape.setValue( page_shape )
+            opCache.outerBlockShape.setValue( page_shape )
+            opCache.Input.connect( mmfReader.Output )
+             
+            return ([mmfReader, opCache], opCache.Output)
         else :
             return ([], None)
     

--- a/lazyflow/operators/ioOperators/opStreamingMmfReader.py
+++ b/lazyflow/operators/ioOperators/opStreamingMmfReader.py
@@ -20,30 +20,6 @@
 #           http://ilastik.org/license/
 ###############################################################################
 
-'''
-MMF reader adapted from JAABA's mmf header reader: https://github.com/kristinbranson/JAABA/blob/master/filehandling/mmf_read_header.m
-
-mmf format documentation (Copied from JAABA's mmf_read_header.m):
-Set of Image Stacks representing a movie. Beginning of file is a header, with this format:
-10240 byte zero padded header beginning with a textual description of the file, followed by \0 then the following fields (all ints, except idcode)
-4 byte unsigned long idcode = a3d2d45d, header size in bytes, key frame interval, threshold below background, threshold above background
-Header is followed by a set of common background image stacks, with the following format:
-Stack of common background images, beginning with this header:
-512 byte zero-padded header, with the following fields (all 4 byte ints, except idcode):
-4 byte unsigned long idcode = bb67ca20, header size in bytes, total size of stack on disk, nframes: number of images in stack
-Then the background image, as an IplImage, starting with the 112 byte image header, followed by the image data
-Then nframes background removed images containing only differences from the background, in this format:
-BackgroundRemovedImage: header is a1024 byte zero padded header with the following data fields (all 4 byte ints, except id code)
-4 byte unsigned long idcode = f80921af, headersize (number of bytes in header), depth (IplImage depth), nChannels (IplImage number of channels), numims (number of 
-image blocks that differ from background) then metadata:
-Name-Value MetaData: idcode (unsigned long) = c15ac674, int number of key-value pairs stored, then each pair
-in the format \0-terminated string of chars then 8 byte double value
-header is followed by numims image blocks of the following form:
-(16 bytes) CvRect [x y w h] describing location of image data, then interlaced row ordered image data
-
-TODO: handle multichannel data, non 8-bit data
-'''
-
 import logging
 import time
 
@@ -77,8 +53,6 @@ class OpStreamingMmfReader(Operator):
 
     def __init__(self, *args, **kwargs):
         super(OpStreamingMmfReader, self).__init__(*args, **kwargs)
-        self._memmapFile = None
-        self._rawVigraArray = None
 
     def setupOutputs(self):
         """
@@ -110,7 +84,6 @@ class OpStreamingMmfReader(Operator):
             frame = self.mmf.getFrame(tStart)
             self.frame = frame[None, :, :, None]
 
-          
         result[...] = self.frame[0:1, yStart:yStop, xStart:xStop, cStart:cStop]
         
     def propagateDirty(self, slot, subindex, roi):

--- a/lazyflow/operators/ioOperators/opStreamingMmfReader.py
+++ b/lazyflow/operators/ioOperators/opStreamingMmfReader.py
@@ -30,13 +30,7 @@ import copy
 
 import MmfParser
 
-from lazyflow.utility import Timer
-
 from lazyflow.graph import Operator, InputSlot, OutputSlot
-from lazyflow.utility import Timer 
-
-import logging
-logger = logging.getLogger(__name__)
 
 AXIS_ORDER = 'tyxc'
 
@@ -68,7 +62,6 @@ class OpStreamingMmfReader(Operator):
         self.mmf = MmfParser.MmfParser(str(fileName))
         frameNum = self.mmf.getNumberOfFrames()
         
-        #try:
         frame = self.mmf.getFrame(0)
         self.frame = frame[None, :, :, None]
 
@@ -76,8 +69,6 @@ class OpStreamingMmfReader(Operator):
         self.Output.meta.axistags = vigra.defaultAxistags(AXIS_ORDER)
         self.Output.meta.shape = (frameNum, self.frame.shape[1], self.frame.shape[2], self.frame.shape[3])
         self.Output.meta.ideal_blockshape = (1,) + self.Output.meta.shape[1:]
-        
-        logger.info("Ideal block shape: {}".format(self.Output.meta.ideal_blockshape))
 
     def execute(self, slot, subindex, roi, result):
         start, stop = roi.start, roi.stop
@@ -86,23 +77,12 @@ class OpStreamingMmfReader(Operator):
         yStart, yStop = start[1], stop[1]
         xStart, xStop = start[2], stop[2]
         cStart, cStop = start[3], stop[3]
+  
+        for tResult, tFrame in enumerate(range(tStart, tStop)) :
+            with self._lock:
+                frame = self.mmf.getFrame(tFrame)
+            result[tResult, ..., 0] = frame[yStart:yStop, xStart:xStop]
 
-        logger.info("t {}:{}, y {}:{}, x {}:{}".format(tStart, tStop, yStart, yStop, xStart, xStop))
-
-        with Timer() as timer :    
-            for tResult, tFrame in enumerate(range(tStart, tStop)):
-                with self._lock:
-                    frame = self.mmf.getFrame(tFrame)
-                result[tResult, ..., 0] = frame[yStart:yStop, xStart:xStop]
-                    
-#             if self.position != tStart :
-#                 self.position = tStart
-#                 frame = self.mmf.getFrame(tStart)
-#                 self.frame = frame[None, :, :, None] 
-#             result[...] = self.frame[0:1, yStart:yStop, xStart:xStop, cStart:cStop]
-                
-        logger.info( " Frame time elapsed: {}".format(timer.seconds()) )
-        
     def propagateDirty(self, slot, subindex, roi):
         if slot == self.FileName:
             self.Output.setDirty( slice(None) )

--- a/lazyflow/operators/ioOperators/opStreamingMmfReader.py
+++ b/lazyflow/operators/ioOperators/opStreamingMmfReader.py
@@ -1,0 +1,123 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#           http://ilastik.org/license/
+###############################################################################
+
+'''
+MMF reader adapted from JAABA's mmf header reader: https://github.com/kristinbranson/JAABA/blob/master/filehandling/mmf_read_header.m
+
+mmf format documentation (Copied from JAABA's mmf_read_header.m):
+Set of Image Stacks representing a movie. Beginning of file is a header, with this format:
+10240 byte zero padded header beginning with a textual description of the file, followed by \0 then the following fields (all ints, except idcode)
+4 byte unsigned long idcode = a3d2d45d, header size in bytes, key frame interval, threshold below background, threshold above background
+Header is followed by a set of common background image stacks, with the following format:
+Stack of common background images, beginning with this header:
+512 byte zero-padded header, with the following fields (all 4 byte ints, except idcode):
+4 byte unsigned long idcode = bb67ca20, header size in bytes, total size of stack on disk, nframes: number of images in stack
+Then the background image, as an IplImage, starting with the 112 byte image header, followed by the image data
+Then nframes background removed images containing only differences from the background, in this format:
+BackgroundRemovedImage: header is a1024 byte zero padded header with the following data fields (all 4 byte ints, except id code)
+4 byte unsigned long idcode = f80921af, headersize (number of bytes in header), depth (IplImage depth), nChannels (IplImage number of channels), numims (number of 
+image blocks that differ from background) then metadata:
+Name-Value MetaData: idcode (unsigned long) = c15ac674, int number of key-value pairs stored, then each pair
+in the format \0-terminated string of chars then 8 byte double value
+header is followed by numims image blocks of the following form:
+(16 bytes) CvRect [x y w h] describing location of image data, then interlaced row ordered image data
+
+TODO: handle multichannel data, non 8-bit data
+'''
+
+import logging
+import time
+
+import numpy
+import vigra
+import copy
+
+import MmfParser
+
+from lazyflow.utility import Timer
+
+from lazyflow.graph import Operator, InputSlot, OutputSlot
+from lazyflow.utility import Timer 
+
+AXIS_ORDER = 'tyxc'
+
+class OpStreamingMmfReader(Operator):
+    """
+    Imports videos in MMF format.
+    """    
+    name = "OpStreamingMmfReader"
+    category = "Input"
+
+    position = None
+    
+    FileName = InputSlot(stype='filestring')
+    Output = OutputSlot()
+
+    class DatasetReadError(Exception):
+        pass
+
+    def __init__(self, *args, **kwargs):
+        super(OpStreamingMmfReader, self).__init__(*args, **kwargs)
+        self._memmapFile = None
+        self._rawVigraArray = None
+
+    def setupOutputs(self):
+        """
+        Load the file specified via our input slot and present its data on the output slot.
+        """
+        fileName = self.FileName.value
+
+        self.mmf = MmfParser.MmfParser(str(fileName))
+        frameNum = self.mmf.getNumberOfFrames()
+        
+        #try:
+        frame = self.mmf.getFrame(0)
+        self.frame = frame[None, :, :, None]
+
+        self.Output.meta.dtype = self.frame.dtype.type
+        self.Output.meta.axistags = vigra.defaultAxistags(AXIS_ORDER)
+        self.Output.meta.shape = (frameNum, self.frame.shape[1], self.frame.shape[2], self.frame.shape[3])
+
+    def execute(self, slot, subindex, roi, result):
+        start, stop = roi.start, roi.stop
+        
+        tStart, tStop = start[0], stop[0]
+        yStart, yStop = start[1], stop[1]
+        xStart, xStop = start[2], stop[2]
+        cStart, cStop = start[3], stop[3]
+            
+        if self.position != tStart :
+            self.position = tStart
+            frame = self.mmf.getFrame(tStart)
+            self.frame = frame[None, :, :, None]
+
+          
+        result[...] = self.frame[0:1, yStart:yStop, xStart:xStop, cStart:cStop]
+        
+    def propagateDirty(self, slot, subindex, roi):
+        if slot == self.FileName:
+            self.Output.setDirty( slice(None) )
+    
+    def cleanUp(self):
+        self.mmf.close()
+        super(OpStreamingMmfReader, self).cleanUp()
+

--- a/lazyflow/operators/ioOperators/opStreamingMmfReader.py
+++ b/lazyflow/operators/ioOperators/opStreamingMmfReader.py
@@ -77,12 +77,12 @@ class OpStreamingMmfReader(Operator):
         xStart, xStop = start[2], stop[2]
         cStart, cStop = start[3], stop[3]
   
-        for tResult, tFrame in enumerate(range(tStart, tStop)) :
-            if self.position != tFrame:
-                with self._lock:
+        for tResult, tFrame in enumerate(range(tStart, tStop)):
+            with self._lock:
+                if self.position != tFrame:
                     self.position = tFrame
                     self.frame = self.mmf.getFrame(tFrame)
-            result[tResult, ..., 0] = self.frame[yStart:yStop, xStart:xStop]
+                result[tResult, ..., 0] = self.frame[yStart:yStop, xStart:xStop]
 
     def propagateDirty(self, slot, subindex, roi):
         if slot == self.FileName:

--- a/lazyflow/operators/ioOperators/opStreamingUfmfReader.py
+++ b/lazyflow/operators/ioOperators/opStreamingUfmfReader.py
@@ -86,12 +86,12 @@ class OpStreamingUfmfReader(Operator):
         cStart, cStop = start[3], stop[3]    
   
         for tResult, tFrame in enumerate(range(tStart, tStop)):
-            if self.position != tFrame:
-                with self._lock:
+            with self._lock:
+                if self.position != tFrame:
                     self.position = tFrame
                     self.fmf.seek(tStart)
                     self.frame, timestamp = self.fmf.get_next_frame()
-            result[tResult, ..., 0] = self.frame[yStart:yStop, xStart:xStop] 
+                result[tResult, ..., 0] = self.frame[yStart:yStop, xStart:xStop] 
 
     def propagateDirty(self, slot, subindex, roi):
         if slot == self.FileName:

--- a/lazyflow/operators/ioOperators/opStreamingUfmfReader.py
+++ b/lazyflow/operators/ioOperators/opStreamingUfmfReader.py
@@ -1,0 +1,103 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#           http://ilastik.org/license/
+###############################################################################
+
+import logging
+import time
+
+import numpy
+import vigra
+import copy
+
+import UfmfParser
+
+from lazyflow.graph import Operator, InputSlot, OutputSlot
+from lazyflow.utility import Timer
+
+logger = logging.getLogger(__name__)    
+
+AXIS_ORDER = 'tyxc'
+
+class OpStreamingUfmfReader(Operator):
+    """
+    Imports videos in uFMF format. For more information refer to the Ctrax file tracker: http://ctrax.sourceforge.net/
+    """    
+    name = "OpStreamingUfmfReader"
+    category = "Input"
+
+    position = None
+    
+    FileName = InputSlot(stype='filestring')
+    Output = OutputSlot()
+
+    class DatasetReadError(Exception):
+        pass
+
+    def __init__(self, *args, **kwargs):
+        super(OpStreamingUfmfReader, self).__init__(*args, **kwargs)
+        self._memmapFile = None
+        self._rawVigraArray = None
+
+    def setupOutputs(self):
+        """
+        Load the file specified via our input slot and present its data on the output slot.
+        """
+        fileName = self.FileName.value
+
+        self.fmf = UfmfParser.FlyMovieEmulator(str(fileName))
+        frameNum = self.fmf.get_n_frames()
+        width = self.fmf.get_width()
+        height = self.fmf.get_height()
+        
+        try:
+            frame, timestamp = self.fmf.get_next_frame()
+            self.frame = frame[None, :, :, None]
+        except FMF.NoMoreFramesException, err:
+            logger.info("Error reading uFMF frame.")
+
+        self.Output.meta.dtype = self.frame.dtype.type
+        self.Output.meta.axistags = vigra.defaultAxistags(AXIS_ORDER)
+        self.Output.meta.shape = (frameNum, self.frame.shape[1], self.frame.shape[2], self.frame.shape[3])
+        
+    def execute(self, slot, subindex, roi, result):
+        start, stop = roi.start, roi.stop
+        
+        tStart, tStop = start[0], stop[0]
+        yStart, yStop = start[1], stop[1]
+        xStart, xStop = start[2], stop[2]
+        cStart, cStop = start[3], stop[3]    
+                  
+        if self.position != tStart :
+            self.position = tStart
+            self.fmf.seek(tStart)
+            frame, timestamp = self.fmf.get_next_frame()
+            self.frame = frame[None, :, :, None]
+          
+        result[...] = self.frame[0:1, yStart:yStop, xStart:xStop, cStart:cStop]
+
+    def propagateDirty(self, slot, subindex, roi):
+        if slot == self.FileName:
+            self.Output.setDirty( slice(None) )
+    
+    def cleanUp(self):
+        self.fmf.close()
+        super(OpStreamingUfmfReader, self).cleanUp()
+

--- a/tests/testOpStreamingMmfReader.py
+++ b/tests/testOpStreamingMmfReader.py
@@ -54,16 +54,6 @@ class TestOpStreamingMmfReader(object):
         mmfReader = OpStreamingMmfReader(graph=self.graph)
         mmfReader.FileName.setValue(self.fileName)  
         output = mmfReader.Output[:].wait()
-        
-        print "Shape: ", output.shape
-        comp = output[0,:,:,0] == output[100,:,:,0]
-        print "Final == Last: ", len(comp[comp==False])
-        
-        plt.imshow(output[0, ..., 0])
-        plt.show()
-    
-        plt.imshow(output[-1, ..., 0])
-        plt.show()
                 
         # Verify shape, data type, and axis tags
         assert output.shape == EXPECTED_SHAPE

--- a/tests/testOpStreamingMmfReader.py
+++ b/tests/testOpStreamingMmfReader.py
@@ -23,6 +23,7 @@ import numpy as np
 import vigra
 from lazyflow.graph import Graph
 from lazyflow.operators.ioOperators import OpStreamingMmfReader
+import nose
 
 EXPECTED_DTYPE = np.uint8
 EXPECTED_SHAPE = (180, 2816, 2816, 1)
@@ -41,6 +42,9 @@ class TestOpStreamingMmfReader(object):
         pass
 
     def test_OpStreamingMmfReader(self):
+        # Skip tests since the MMF video file is not located in the folder by default.
+        raise nose.SkipTest     
+    
         # Test the mmf streaming reading operator with a small video containing 180 frames
         self.graph = Graph()
         mmfReader = OpStreamingMmfReader(graph=self.graph)

--- a/tests/testOpStreamingMmfReader.py
+++ b/tests/testOpStreamingMmfReader.py
@@ -19,11 +19,14 @@
 # This information is also available on the ilastik web site at:
 #		   http://ilastik.org/license/
 ###############################################################################
+import os
 import numpy as np
 import vigra
 from lazyflow.graph import Graph
 from lazyflow.operators.ioOperators import OpStreamingMmfReader
 import nose
+
+import pylab as plt
 
 EXPECTED_DTYPE = np.uint8
 EXPECTED_SHAPE = (180, 2816, 2816, 1)
@@ -42,8 +45,9 @@ class TestOpStreamingMmfReader(object):
         pass
 
     def test_OpStreamingMmfReader(self):
-        # Skip tests since the MMF video file is not located in the folder by default.
-        raise nose.SkipTest     
+        # Skip tests since the MMF video file is not found
+        if not os.path.isfile(self.fileName):
+            raise nose.SkipTest     
     
         # Test the mmf streaming reading operator with a small video containing 180 frames
         self.graph = Graph()
@@ -51,6 +55,16 @@ class TestOpStreamingMmfReader(object):
         mmfReader.FileName.setValue(self.fileName)  
         output = mmfReader.Output[:].wait()
         
+        print "Shape: ", output.shape
+        comp = output[0,:,:,0] == output[100,:,:,0]
+        print "Final == Last: ", len(comp[comp==False])
+        
+        plt.imshow(output[0, ..., 0])
+        plt.show()
+    
+        plt.imshow(output[-1, ..., 0])
+        plt.show()
+                
         # Verify shape, data type, and axis tags
         assert output.shape == EXPECTED_SHAPE
         assert mmfReader.Output.meta.dtype == EXPECTED_DTYPE

--- a/tests/testOpStreamingMmfReader.py
+++ b/tests/testOpStreamingMmfReader.py
@@ -1,0 +1,61 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#		   http://ilastik.org/license/
+###############################################################################
+import numpy as np
+import vigra
+from lazyflow.graph import Graph
+from lazyflow.operators.ioOperators import OpStreamingMmfReader
+
+EXPECTED_DTYPE = np.uint8
+EXPECTED_SHAPE = (180, 2816, 2816, 1)
+EXPECTED_AXIS_ORDER = 'tyxc'
+FILE_NAME = 'zlatic_larvae_200frames.mmf'
+
+
+class TestOpStreamingMmfReader(object):
+    # In order for this tests to work, you need to include the file 'zlatic_larvae_200frames.mmf' in the same directory. 
+    # This file can be downloaded from the following GitHub repository: https://github.com/ilastik/ilastik_testdata
+
+    def setUp(self):
+        self.fileName = FILE_NAME
+
+    def tearDown(self):
+        pass
+
+    def test_OpStreamingMmfReader(self):
+        # Test the mmf streaming reading operator with a small video containing 180 frames
+        self.graph = Graph()
+        mmfReader = OpStreamingMmfReader(graph=self.graph)
+        mmfReader.FileName.setValue(self.fileName)  
+        output = mmfReader.Output[:].wait()
+        
+        # Verify shape, data type, and axis tags
+        assert output.shape == EXPECTED_SHAPE
+        assert mmfReader.Output.meta.dtype == EXPECTED_DTYPE
+        assert mmfReader.Output.meta.axistags == vigra.defaultAxistags(EXPECTED_AXIS_ORDER)
+        
+        # Clean reader
+        mmfReader.cleanUp()
+        
+if __name__ == "__main__":
+    import nose
+    ret = nose.run(defaultTest=__file__, env={'NOSE_NOCAPTURE' : 1})
+    if not ret: sys.exit(1)

--- a/tests/testOpStreamingUfmfReader.py
+++ b/tests/testOpStreamingUfmfReader.py
@@ -1,0 +1,88 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#		   http://ilastik.org/license/
+###############################################################################
+import os
+import tempfile
+import numpy as np
+import vigra
+from lazyflow.graph import Graph
+from lazyflow.operators.ioOperators import OpStreamingUfmfReader
+from lazyflow.operators.ioOperators import UfmfParser
+
+VERSION = 3
+WIDTH = 640
+HEIGHT = 480 
+FRAME_NUM = 100 
+
+EXPECTED_DTYPE = np.uint8
+EXPECTED_SHAPE = (100, 480, 640, 1)
+EXPECTED_AXIS_ORDER = 'tyxc'
+
+class TestOpStreamingUfmfReader(object):
+
+    def setUp(self):
+        # Write a simple uFMF video with 100 frames.
+        tmpDir = tempfile.gettempdir()
+        self.testUfmfFileName = os.path.join(tmpDir, 'ufmfTestVideo.ufmf')
+         
+        if VERSION==1 :
+            kwargs = dict(image_radius=radius)
+        else:
+            kwargs = dict(max_width=WIDTH, max_height=HEIGHT,)
+        
+        frame0 = np.full( (HEIGHT, WIDTH), 255, dtype=np.uint8)    
+        timestamp0 = 0
+        
+        ufmfFile = UfmfParser.UfmfSaver( self.testUfmfFileName, frame0, timestamp0, version=VERSION, **kwargs)
+        
+        pts = [ (0, 0, WIDTH, HEIGHT) ]
+        
+        for fmi in range(FRAME_NUM) :
+            frame = np.full( (HEIGHT ,WIDTH), 255, dtype=np.uint8)  
+            frame[(HEIGHT/FRAME_NUM)*fmi:(HEIGHT/FRAME_NUM)*fmi+FRAME_NUM, (WIDTH/FRAME_NUM)*fmi:(WIDTH/FRAME_NUM)*fmi+FRAME_NUM] = 50
+            timestamp = fmi+1
+            ufmfFile.add_frame( frame, timestamp, pts )   
+        
+        ufmfFile.close()
+        
+    def tearDown(self):
+        # Delete the ufmf test file.
+        os.remove(self.testUfmfFileName)
+
+    def test_OpStreamingUfmfReader(self):
+        # Tests the ufmf reader operator, opening a small video that is created on setUp.
+        self.graph = Graph()
+        ufmfReader = OpStreamingUfmfReader(graph=self.graph)
+        ufmfReader.FileName.setValue(self.testUfmfFileName)  
+        output = ufmfReader.Output[:].wait()
+        
+        # Verify shape, data type, and axis tags
+        assert output.shape == EXPECTED_SHAPE
+        assert ufmfReader.Output.meta.dtype == EXPECTED_DTYPE
+        assert ufmfReader.Output.meta.axistags == vigra.defaultAxistags(EXPECTED_AXIS_ORDER)
+        
+        # Clean reader
+        ufmfReader.cleanUp()
+        
+if __name__ == "__main__":
+    import nose
+    ret = nose.run(defaultTest=__file__, env={'NOSE_NOCAPTURE' : 1})
+    if not ret: sys.exit(1)


### PR DESCRIPTION
Added MMF and uFMF video reader operators. 
For more information on the uFMF format refer to Ctrax: http://ctrax.sourceforge.net/
For more information on the MMF format refer to the JAABA project: https://github.com/kristinbranson/JAABA. 

Some notes on the changes:
* The files `FlyMovieFormat.py` and `UfmfParser.py` were copied directly from the Ctrax source code.
* The file `MmfParser.py` was adapted from JAABA's `mmf_read_header.m`: https://github.com/kristinbranson/JAABA/blob/master/filehandling/mmf_read_header.m

To do:
* Add MMF multi-channel support.
* Optimize MMF reading speed.
