### PR TITLE
Variable Importance Table GUI

### DIFF
--- a/lazyflow/classifiers/parallelVigraRfLazyflowClassifier.py
+++ b/lazyflow/classifiers/parallelVigraRfLazyflowClassifier.py
@@ -189,6 +189,7 @@ class ParallelVigraRfLazyflowClassifierFactory(LazyflowVectorwiseClassifierFacto
     def __eq__(self, other):
         return (    isinstance(other, type(self))
                 and self._num_trees == other._num_trees
+                and self._variable_importance_enabled == other._variable_importance_enabled
                 and self._kwargs == other._kwargs )
     def __ne__(self, other):
         return not self.__eq__(other)


### PR DESCRIPTION
Modified the parallel RF classifier to be compatible with the variable importance table GUI, by adding a public static variable called `named_importances` which is accessed from `VariableImportanceDialog`. A bug in the `_eq_` operator was also fixed in order to retrain the classifier when `variable_importance_enabled` is set to True. This pull request is associated with the corresponding pull request in ilastik: https://github.com/ilastik/ilastik/pull/1150