### PR TITLE
Changed parameters to optimize the memory of CacheMemoryManager and BigRequestStreamer

### DIFF
--- a/lazyflow/operators/cacheMemoryManager.py
+++ b/lazyflow/operators/cacheMemoryManager.py
@@ -39,7 +39,7 @@ from lazyflow.utility import Memory
 import logging
 logger = logging.getLogger(__name__)
 
-default_refresh_interval = 5
+default_refresh_interval = 1
 
 
 class CacheMemoryManager(threading.Thread):

--- a/lazyflow/utility/bigRequestStreamer.py
+++ b/lazyflow/utility/bigRequestStreamer.py
@@ -97,7 +97,7 @@ class BigRequestStreamer(object):
         totalVolume = numpy.prod( numpy.subtract(roi[1], roi[0]) )
         
         if batchSize is None:
-            batchSize=1000
+            batchSize=32
         
         if blockshape is None:
             blockshape = self._determine_blockshape(outputSlot)


### PR DESCRIPTION
Changed parameters to optimize the memory of `CacheMemoryManager` and `BigRequestStreamer`:
* Set the refresh interval that checks the process memory from 5 seconds to 1 second.
* Changed the batch size from 1000 to 32 in the bigRequestStreamer.