### PR TITLE
try-except -> if

### DIFF
--- a/lazyflow/classifiers/parallelVigraRfLazyflowClassifier.py
+++ b/lazyflow/classifiers/parallelVigraRfLazyflowClassifier.py
@@ -365,15 +365,15 @@ class ParallelVigraRfLazyflowClassifier(LazyflowVectorwiseClassifierABC):
             # Older projects didn't store the labels explicitly.
             known_labels = range(1, forests[0].labelCount()+1 )
 
-        try:
+        if 'feature_names' in h5py_group.keys():
             feature_names = list(h5py_group['feature_names'][:])
-        except KeyError:
+        else:
             # Older projects don't store feature names.
             feature_names = None
 
-        try:
+        if 'oobs' in h5py_group.keys():
             oobs = list(h5py_group['oobs'][:])
-        except KeyError:
+        else:
             # Older projects didn't store the oobs.
             # Just provide something obviously invalid.
             oobs = [-1.0] * len(forests)


### PR DESCRIPTION
This happens on my machine when a subgroup is accessed that doesn't exist in the .h5 file. Not sure if this is a bug in h5py itself but arguably if 'key' in grp.keys() is cleaner than try-except anyways.

```(gdb) 
Continuing.

Program received signal SIGSEGV, Segmentation fault.
0x00007f0ddb595649 in raise () from /lib64/libpthread.so.0
(gdb) bt
#0  0x00007f0ddb595649 in raise () from /lib64/libpthread.so.0
#1  <signal handler called>
#2  0x00007f0dd02c0660 in __pyx_type_4h5py_3h5p_PropID () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/h5py/h5p.so
#3  0x00007f0dd91443f6 in __pyx_f_4h5py_4defs_H5Oopen (__pyx_v_loc_id=<optimized out>, __pyx_v_name=<optimized out>, __pyx_v_lapl_id=<optimized out>) at --------src-dir--------/h5py-2.5.0/h5py/defs.c:11464
#4  0x00007f0dceb94124 in __pyx_pf_4h5py_3h5o_4open (__pyx_v_lapl=0x7f0d60d0b780, __pyx_v_name=0x7f0dda0f2287 <H5Oopen+423> "\351\r\377\377\377H\215\005\223\367\023", __pyx_v_loc=0x7f0db43f3c94, __pyx_self=<optimized out>)
    at --------src-dir--------/h5py-2.5.0/h5py/h5o.c:3507
#5  __pyx_pw_4h5py_3h5o_5open (__pyx_self=<optimized out>, __pyx_args=<optimized out>, __pyx_kwds=<optimized out>) at --------src-dir--------/h5py-2.5.0/h5py/h5o.c:3478
#6  0x00007f0dd936391c in __Pyx_PyObject_Call (kw=<optimized out>, arg=<optimized out>, func=<optimized out>) at --------src-dir--------/h5py-2.5.0/h5py/_objects.c:7399
#7  __pyx_pf_4h5py_8_objects_9with_phil_wrapper (__pyx_v_kwds=0x7f0d3b36db40, __pyx_v_args=0x7f0d3b36e638, __pyx_self=<optimized out>) at --------src-dir--------/h5py-2.5.0/h5py/_objects.c:2415
#8  __pyx_pw_4h5py_8_objects_9with_phil_1wrapper (__pyx_self=<optimized out>, __pyx_args=0x7f0d3b36e638, __pyx_kwds=<optimized out>) at --------src-dir--------/h5py-2.5.0/h5py/_objects.c:2331
#9  0x00007f0ddb7ead23 in PyObject_Call (func=0x7f0dcedaa290, arg=<optimized out>, kw=<optimized out>) at Objects/abstract.c:2546
#10 0x00007f0ddb89bf54 in do_call (nk=<optimized out>, na=<optimized out>, pp_stack=0x7ffc21c0b4f8, func=0x7f0dcedaa290) at Python/ceval.c:4568
#11 call_function (oparg=<optimized out>, pp_stack=0x7ffc21c0b4f8) at Python/ceval.c:4373
#12 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2987
#13 0x00007f0ddb89ea2e in PyEval_EvalCodeEx (co=0x7f0dcedb15b0, globals=<optimized out>, locals=<optimized out>, args=<optimized out>, argcount=2, kws=0x7f0ddbd2b068, kwcount=0, defs=0x0, defcount=0, closure=0x0) at Python/ceval.c:3582
#14 0x00007f0ddb81a4a8 in function_call (func=0x7f0dceddbcf8, arg=0x7f0d3b3a8368, kw=0x7f0d3b36dc58) at Objects/funcobject.c:526
#15 0x00007f0dd936391c in __Pyx_PyObject_Call (kw=<optimized out>, arg=<optimized out>, func=<optimized out>) at --------src-dir--------/h5py-2.5.0/h5py/_objects.c:7399
#16 __pyx_pf_4h5py_8_objects_9with_phil_wrapper (__pyx_v_kwds=0x7f0d3b36dc58, __pyx_v_args=0x7f0d3b3a8368, __pyx_self=<optimized out>) at --------src-dir--------/h5py-2.5.0/h5py/_objects.c:2415
#17 __pyx_pw_4h5py_8_objects_9with_phil_1wrapper (__pyx_self=<optimized out>, __pyx_args=0x7f0d3b3a8368, __pyx_kwds=<optimized out>) at --------src-dir--------/h5py-2.5.0/h5py/_objects.c:2331
#18 0x00007f0ddb7ead23 in PyObject_Call (func=0x7f0dce93a410, arg=<optimized out>, kw=<optimized out>) at Objects/abstract.c:2546
#19 0x00007f0ddb7fd4bf in instancemethod_call (func=0x7f0dce93a410, arg=0x7f0d3b3a8368, kw=0x0) at Objects/classobject.c:2602
#20 0x00007f0ddb7ead23 in PyObject_Call (func=0x7f0d880b79b0, arg=<optimized out>, kw=<optimized out>) at Objects/abstract.c:2546
#21 0x00007f0ddb8542d5 in call_method (o=<optimized out>, name=<optimized out>, nameobj=0x7f0ddbb7b2f8 <cache_str>, format=0x7f0ddb8f1757 "(O)") at Objects/typeobject.c:1261
#22 0x00007f0ddb896857 in PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:1539
#23 0x00007f0ddb89db95 in fast_function (nk=<optimized out>, na=<optimized out>, n=<optimized out>, pp_stack=0x7ffc21c0bd88, func=0x7f0db41e1050) at Python/ceval.c:4436
#24 call_function (oparg=<optimized out>, pp_stack=0x7ffc21c0bd88) at Python/ceval.c:4371
#25 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2987
#26 0x00007f0ddb89db95 in fast_function (nk=<optimized out>, na=<optimized out>, n=<optimized out>, pp_stack=0x7ffc21c0bef8, func=0x7f0d9abb0a28) at Python/ceval.c:4436
#27 call_function (oparg=<optimized out>, pp_stack=0x7ffc21c0bef8) at Python/ceval.c:4371
#28 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2987
#29 0x00007f0ddb89db95 in fast_function (nk=<optimized out>, na=<optimized out>, n=<optimized out>, pp_stack=0x7ffc21c0c068, func=0x7f0d9abb01b8) at Python/ceval.c:4436
#30 call_function (oparg=<optimized out>, pp_stack=0x7ffc21c0c068) at Python/ceval.c:4371
#31 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2987
#32 0x00007f0ddb89db95 in fast_function (nk=<optimized out>, na=<optimized out>, n=<optimized out>, pp_stack=0x7ffc21c0c1d8, func=0x7f0d9abb09b0) at Python/ceval.c:4436
#33 call_function (oparg=<optimized out>, pp_stack=0x7ffc21c0c1d8) at Python/ceval.c:4371
#34 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2987
#35 0x00007f0ddb89ea2e in PyEval_EvalCodeEx (co=0x7f0d9abaaab0, globals=<optimized out>, locals=<optimized out>, args=<optimized out>, argcount=3, kws=0x3697ea8, kwcount=0, defs=0x7f0d9abacb68, defcount=1, closure=0x0) at Python/ceval.c:3582
#36 0x00007f0ddb89da55 in fast_function (nk=<optimized out>, na=3, n=<optimized out>, pp_stack=0x7ffc21c0c3f8, func=0x7f0d9abb5848) at Python/ceval.c:4446
#37 call_function (oparg=<optimized out>, pp_stack=0x7ffc21c0c3f8) at Python/ceval.c:4371
#38 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2987
#39 0x00007f0ddb89ea2e in PyEval_EvalCodeEx (co=0x7f0d9ac567b0, globals=<optimized out>, locals=<optimized out>, args=<optimized out>, argcount=4, kws=0x7f0ddbd2b068, kwcount=0, defs=0x0, defcount=0, closure=0x0) at Python/ceval.c:3582
#40 0x00007f0ddb81a4a8 in function_call (func=0x7f0d9ac5c5f0, arg=0x7f0d880a7890, kw=0x7f0d88079280) at Objects/funcobject.c:526
#41 0x00007f0ddb7ead23 in PyObject_Call (func=0x7f0d9ac5c5f0, arg=<optimized out>, kw=<optimized out>) at Objects/abstract.c:2546
#42 0x00007f0ddb89b797 in ext_do_call (nk=-2012579696, na=<optimized out>, flags=<optimized out>, pp_stack=0x7ffc21c0c6e8, func=0x7f0d9ac5c5f0) at Python/ceval.c:4663
#43 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:3026
#44 0x00007f0ddb89ea2e in PyEval_EvalCodeEx (co=0x7f0db45ca0b0, globals=<optimized out>, locals=<optimized out>, args=<optimized out>, argcount=4, kws=0x3116a98, kwcount=0, defs=0x0, defcount=0, closure=0x7f0d9ac582d0) at Python/ceval.c:3582
#45 0x00007f0ddb89da55 in fast_function (nk=<optimized out>, na=4, n=<optimized out>, pp_stack=0x7ffc21c0c908, func=0x7f0d9ac5c668) at Python/ceval.c:4446
#46 call_function (oparg=<optimized out>, pp_stack=0x7ffc21c0c908) at Python/ceval.c:4371
#47 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2987
#48 0x00007f0ddb89ea2e in PyEval_EvalCodeEx (co=0x7f0dbc7a64b0, globals=<optimized out>, locals=<optimized out>, args=<optimized out>, argcount=5, kws=0x2f77150, kwcount=0, defs=0x7f0d936b0628, defcount=1, closure=0x0) at Python/ceval.c:3582
#49 0x00007f0ddb89da55 in fast_function (nk=<optimized out>, na=5, n=<optimized out>, pp_stack=0x7ffc21c0cb28, func=0x7f0d93525758) at Python/ceval.c:4446
#50 call_function (oparg=<optimized out>, pp_stack=0x7ffc21c0cb28) at Python/ceval.c:4371
#51 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2987
#52 0x00007f0ddb89ea2e in PyEval_EvalCodeEx (co=0x7f0dbc7a6430, globals=<optimized out>, locals=<optimized out>, args=<optimized out>, argcount=2, kws=0x7f0d93434c68, kwcount=0, defs=0x7f0d936b05e8, defcount=1, closure=0x0) at Python/ceval.c:3582
#53 0x00007f0ddb89da55 in fast_function (nk=<optimized out>, na=2, n=<optimized out>, pp_stack=0x7ffc21c0cd48, func=0x7f0d935256e0) at Python/ceval.c:4446
#54 call_function (oparg=<optimized out>, pp_stack=0x7ffc21c0cd48) at Python/ceval.c:4371
#55 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2987
#56 0x00007f0ddb89ea2e in PyEval_EvalCodeEx (co=0x7f0dbc797930, globals=<optimized out>, locals=<optimized out>, args=<optimized out>, argcount=2, kws=0x7f0ddbd2b068, kwcount=0, defs=0x0, defcount=0, closure=0x0) at Python/ceval.c:3582
#57 0x00007f0ddb81a4a8 in function_call (func=0x7f0d935232a8, arg=0x7f0dce199ea8, kw=0x7f0d932fe5c8) at Objects/funcobject.c:526
#58 0x00007f0ddb7ead23 in PyObject_Call (func=0x7f0d935232a8, arg=<optimized out>, kw=<optimized out>) at Objects/abstract.c:2546
#59 0x00007f0ddb7fd4bf in instancemethod_call (func=0x7f0d935232a8, arg=0x7f0dce199ea8, kw=0x7f0d932fe5c8) at Objects/classobject.c:2602
#60 0x00007f0ddb7ead23 in PyObject_Call (func=0x7f0d93408370, arg=<optimized out>, kw=<optimized out>) at Objects/abstract.c:2546
#61 0x00007f0dd8f30714 in partial_call (pto=0x7f0d9340c2b8, args=<optimized out>, kw=0x0) at -------src-dir-------/Python-2.7.11/Modules/_functoolsmodule.c:201
#62 0x00007f0ddb7ead23 in PyObject_Call (func=0x7f0d9340c2b8, arg=<optimized out>, kw=<optimized out>) at Objects/abstract.c:2546
#63 0x00007f0ddb894633 in PyEval_CallObjectWithKeywords (func=0x7f0d9340c2b8, arg=0x7f0ddbd2b050, kw=<optimized out>) at Python/ceval.c:4219
#64 0x00007f0dc49e4540 in ?? () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/sip.so
#65 0x00007f0dc4710511 in ?? () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/QtCore.so
#66 0x00007f0dc47107f6 in ?? () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/QtCore.so
#67 0x00007f0dc471087a in ?? () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/QtCore.so
#68 0x00007f0dcc64ea90 in QMetaObject::activate(QObject*, QMetaObject const*, int, void**) () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtCore.so.4
#69 0x00007f0dc7b95292 in QAbstractButton::clicked(bool) () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
#70 0x00007f0dc78a180b in ?? () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
#71 0x00007f0dc78a2cc5 in ?? () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
---Type <return> to continue, or q <return> to quit---
#72 0x00007f0dc78a2f1b in QAbstractButton::mouseReleaseEvent(QMouseEvent*) () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
#73 0x00007f0dc796dafa in QToolButton::mouseReleaseEvent(QMouseEvent*) () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
#74 0x00007f0dccbe4b8b in ?? () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/QtGui.so
#75 0x00007f0dc74fdafc in QWidget::event(QEvent*) () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
#76 0x00007f0dc78a206f in QAbstractButton::event(QEvent*) () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
#77 0x00007f0dc796f86d in QToolButton::event(QEvent*) () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
#78 0x00007f0dccbe40bb in ?? () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/QtGui.so
#79 0x00007f0dc74a7fef in QApplicationPrivate::notify_helper(QObject*, QEvent*) () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
#80 0x00007f0dc74afde1 in QApplication::notify(QObject*, QEvent*) () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
#81 0x00007f0dccecaf8e in ?? () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/QtGui.so
#82 0x00007f0dcc6375f4 in QCoreApplication::notifyInternal(QObject*, QEvent*) () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtCore.so.4
#83 0x00007f0dc74aaf46 in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool) ()
   from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
#84 0x00007f0dc7529609 in ?? () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
#85 0x00007f0dc7528313 in QApplication::x11ProcessEvent(_XEvent*) () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
#86 0x00007f0dc75537a2 in ?? () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
#87 0x00007f0dc6961e3d in g_main_context_dispatch () from /usr/lib64/libglib-2.0.so.0
#88 0x00007f0dc6962120 in g_main_context_iterate.isra () from /usr/lib64/libglib-2.0.so.0
#89 0x00007f0dc69621cc in g_main_context_iteration () from /usr/lib64/libglib-2.0.so.0
#90 0x00007f0dcc668c65 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtCore.so.4
#91 0x00007f0dc75532ef in ?? () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtGui.so.4
#92 0x00007f0dcc6366b5 in QEventLoop::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtCore.so.4
#93 0x00007f0dcc636a88 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtCore.so.4
#94 0x00007f0dcc63b456 in QCoreApplication::exec() () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/../../../libQtCore.so.4
#95 0x00007f0dccecbc8d in ?? () from /home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/PyQt4/QtGui.so
#96 0x00007f0ddb89de15 in call_function (oparg=<optimized out>, pp_stack=0x7ffc21c0ed88) at Python/ceval.c:4350
#97 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2987
#98 0x00007f0ddb89db95 in fast_function (nk=<optimized out>, na=<optimized out>, n=<optimized out>, pp_stack=0x7ffc21c0eef8, func=0x7f0dc44aacf8) at Python/ceval.c:4436
#99 call_function (oparg=<optimized out>, pp_stack=0x7ffc21c0eef8) at Python/ceval.c:4371
#100 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2987
#101 0x00007f0ddb89ea2e in PyEval_EvalCodeEx (co=0x7f0ddbc49930, globals=<optimized out>, locals=<optimized out>, args=<optimized out>, argcount=2, kws=0x7f0ddbd25f98, kwcount=0, defs=0x7f0dce679da8, defcount=1, closure=0x0) at Python/ceval.c:3582
#102 0x00007f0ddb89da55 in fast_function (nk=<optimized out>, na=2, n=<optimized out>, pp_stack=0x7ffc21c0f118, func=0x7f0dce6927d0) at Python/ceval.c:4446
#103 call_function (oparg=<optimized out>, pp_stack=0x7ffc21c0f118) at Python/ceval.c:4371
#104 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2987
#105 0x00007f0ddb89db95 in fast_function (nk=<optimized out>, na=<optimized out>, n=<optimized out>, pp_stack=0x7ffc21c0f288, func=0x7f0ddbc5cc08) at Python/ceval.c:4436
#106 call_function (oparg=<optimized out>, pp_stack=0x7ffc21c0f288) at Python/ceval.c:4371
#107 PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at Python/ceval.c:2987
#108 0x00007f0ddb89ea2e in PyEval_EvalCodeEx (co=0x7f0ddbc498b0, globals=<optimized out>, locals=<optimized out>, args=<optimized out>, argcount=0, kws=0x0, kwcount=0, defs=0x0, defcount=0, closure=0x0) at Python/ceval.c:3582
#109 0x00007f0ddb89eb42 in PyEval_EvalCode (co=<optimized out>, globals=<optimized out>, locals=<optimized out>) at Python/ceval.c:669
#110 0x00007f0ddb8bf050 in run_mod (arena=0x6752c0, flags=0x7ffc21c0f580, locals=0x7f0ddbd00168, globals=0x7f0ddbd00168, filename=<optimized out>, mod=0x6bddc0) at Python/pythonrun.c:1370
#111 PyRun_FileExFlags (fp=0x6a6d50, filename=<optimized out>, start=<optimized out>, globals=0x7f0ddbd00168, locals=0x7f0ddbd00168, closeit=1, flags=0x7ffc21c0f580) at Python/pythonrun.c:1356
#112 0x00007f0ddb8bf22f in PyRun_SimpleFileExFlags (fp=0x6a6d50, filename=0x7ffc21c10ca2 "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/ilastik/ilastik.py", closeit=1, flags=0x7ffc21c0f580) at Python/pythonrun.c:948
#113 0x00007f0ddb8d4b74 in Py_Main (argc=<optimized out>, argv=<optimized out>) at Modules/main.c:645
#114 0x00007f0ddab097b0 in __libc_start_main () from /lib64/libc.so.6
#115 0x0000000000400649 in _start ()
(gdb) q
A debugging session is active.

	Inferior 1 [process 5702] will be detached.

Quit anyway? (y or n) y
Detaching from program: /home/speter/miniconda2/envs/ilastik-devel-wsdt/bin/python2.7, process 5702
gdb  8.72s user 0.92s system 6% cpu 2:23.17 total
```


```
[...]
calling h5o.open(<h5py.h5g.GroupID object at 0x7f6c3a4c5640>, Forest0008)
calling h5o.open(<h5py.h5g.GroupID object at 0x7f6c3a4c5640>, Forest0009)
calling h5o.open(<h5py.h5g.GroupID object at 0x7f6c3a4c5640>, Forest0010)
calling h5o.open(<h5py.h5g.GroupID object at 0x7f6c3a4c5640>, Forest0011)
calling h5o.open(<h5py.h5g.GroupID object at 0x7f6c3a4c5640>, Forest0012)
calling h5o.open(<h5py.h5g.GroupID object at 0x7f6c3a4c5640>, Forest0013)
calling h5o.open(<h5py.h5g.GroupID object at 0x7f6c3a4c5640>, Forest0014)
calling h5o.open(<h5py.h5g.GroupID object at 0x7f6c3a4c5640>, Forest0015)
calling h5o.open(<h5py.h5g.GroupID object at 0x7f6c3a4c5640>, known_labels)
calling h5o.open(<h5py.h5g.GroupID object at 0x7f6c3a4c5640>, pickled_type)
calling h5o.open(<h5py.h5g.GroupID object at 0x7f6c3a4c5640>, known_labels)
calling h5o.open(<h5py.h5g.GroupID object at 0x7f6c3a4c5640>, feature_names)
Fatal Python error: Segmentation fault

Thread 0x00007f6ca2aff700 (most recent call first):
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 359 in wait
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 614 in wait
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 1071 in run
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 801 in __bootstrap_inner
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 774 in __bootstrap

Thread 0x00007f6c67b3e700 (most recent call first):
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 359 in wait
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/lazyflow/lazyflow/operators/cacheMemoryManager.py", line 241 in _wait
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/lazyflow/lazyflow/operators/cacheMemoryManager.py", line 159 in run
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 801 in __bootstrap_inner
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 774 in __bootstrap

Thread 0x00007f6c89ba2700 (most recent call first):
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 340 in wait
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/lazyflow/lazyflow/request/threadPool.py", line 208 in _get_next_job
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/lazyflow/lazyflow/request/threadPool.py", line 157 in run
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 801 in __bootstrap_inner
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 774 in __bootstrap

Thread 0x00007f6c8a3a3700 (most recent call first):
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 340 in wait
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/lazyflow/lazyflow/request/threadPool.py", line 208 in _get_next_job
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/lazyflow/lazyflow/request/threadPool.py", line 157 in run
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 801 in __bootstrap_inner
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 774 in __bootstrap

Thread 0x00007f6c8aba4700 (most recent call first):
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 340 in wait
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/lazyflow/lazyflow/request/threadPool.py", line 208 in _get_next_job
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/lazyflow/lazyflow/request/threadPool.py", line 157 in run
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 801 in __bootstrap_inner
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 774 in __bootstrap

Thread 0x00007f6c8b3a5700 (most recent call first):
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 340 in wait
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/lazyflow/lazyflow/request/threadPool.py", line 208 in _get_next_job
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/lazyflow/lazyflow/request/threadPool.py", line 157 in run
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 801 in __bootstrap_inner
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/threading.py", line 774 in __bootstrap

Current thread 0x00007f6cb0b32700 (most recent call first):
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/lib/python2.7/site-packages/h5py/_hl/group.py", line 165 in __getitem__
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/lazyflow/lazyflow/classifiers/parallelVigraRfLazyflowClassifier.py", line 369 in deserialize_hdf5
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/ilastik/ilastik/applets/base/appletSerializer.py", line 598 in _deserialize
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/ilastik/ilastik/applets/base/appletSerializer.py", line 243 in deserialize
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/ilastik/ilastik/applets/base/appletSerializer.py", line 586 in deserialize
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/ilastik/ilastik/applets/base/appletSerializer.py", line 1009 in deserializeFromHdf5
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/ilastik/ilastik/shell/projectManager.py", line 435 in _loadProject
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/lazyflow/lazyflow/utility/timer.py", line 142 in wrapper
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/ilastik/ilastik/shell/gui/ilastikShell.py", line 1357 in _loadProject
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/ilastik/ilastik/shell/gui/ilastikShell.py", line 1306 in openProjectFile
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/ilastik/ilastik/shell/gui/ilastikShell.py", line 586 in openFileAndCloseStartscreen
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/ilastik/ilastik/shell/gui/startShellGui.py", line 69 in startShellGui
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/ilastik/ilastik_main.py", line 107 in main
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/ilastik/ilastik.py", line 106 in main
  File "/home/speter/miniconda2/envs/ilastik-devel-wsdt/ilastik-meta/ilastik/ilastik.py", line 113 in <module>
/home/speter/miniconda2/envs/ilastik-devel-wsdt/run_ilastik.sh: line 57:  7153 Segmentation fault      ${PREFIX}/bin/python ${PREFIX}/ilastik-meta/ilastik/ilastik.py "$@"
~/miniconda2/envs/ilastik-devel-wsdt/run_ilastik.sh --debug  17.71s user 0.61s system 85% cpu 21.434 total

```