### PR TITLE
opCompressedCache: Set the ideal_blockshape to the shape of a single frame

### DIFF
--- a/lazyflow/operators/opCompressedCache.py
+++ b/lazyflow/operators/opCompressedCache.py
@@ -131,7 +131,7 @@ class OpUnmanagedCompressedCache(Operator):
             # If the blockshape changes, we have to reset the entire cache.
             self._init_cache(new_blockshape)
 
-        self.Output.meta.ideal_blockshape = self._chunkshape
+        self.Output.meta.ideal_blockshape = new_blockshape
         
 
     def execute(self, slot, subindex, roi, destination):


### PR DESCRIPTION
Set the `ideal_blockshape` of the compressed cache to the shape of a single frame instead of the shape of the HDF5 chunk.