### PR TITLE
Integrated Sven's fast filters

### DIFF
--- a/lazyflow/operators/vigraOperators.py
+++ b/lazyflow/operators/vigraOperators.py
@@ -131,8 +131,6 @@ class OpPixelFeaturesPresmoothed(Operator):
     name="OpPixelFeaturesPresmoothed"
     category = "Vigra filter"
 
-    withFastFilters = InputSlot(value=WITH_FAST_FILTERS)
-
     inputSlots = [InputSlot("Input"),
                   InputSlot("Matrix"),
                   InputSlot("Scales"),
@@ -219,7 +217,7 @@ class OpPixelFeaturesPresmoothed(Operator):
         for i, featureId in enumerate(self.inputs["FeatureIds"].value):
             if featureId == 'GaussianSmoothing':
                 for j in range(dimCol):
-                    if self.withFastFilters.value:
+                    if WITH_FAST_FILTERS:
                         oparray[i].append(OpGaussianSmoothingFF(self))
                     else:
                         oparray[i].append(OpGaussianSmoothing(self))
@@ -230,7 +228,7 @@ class OpPixelFeaturesPresmoothed(Operator):
 
             elif featureId == 'LaplacianOfGaussian':
                 for j in range(dimCol):
-                    if self.withFastFilters.value:
+                    if WITH_FAST_FILTERS:
                         oparray[i].append(OpLaplacianOfGaussianFF(self))
                     else:
                         oparray[i].append(OpLaplacianOfGaussian(self))
@@ -240,7 +238,7 @@ class OpPixelFeaturesPresmoothed(Operator):
 
             elif featureId == 'StructureTensorEigenvalues':
                 for j in range(dimCol):
-                    if self.withFastFilters.value:
+                    if WITH_FAST_FILTERS:
                         oparray[i].append(OpStructureTensorEigenvaluesFF(self))
                     else:
                         oparray[i].append(OpStructureTensorEigenvalues(self))
@@ -257,7 +255,7 @@ class OpPixelFeaturesPresmoothed(Operator):
 
             elif featureId == 'HessianOfGaussianEigenvalues':
                 for j in range(dimCol):
-                    if self.withFastFilters.value:
+                    if WITH_FAST_FILTERS:
                         oparray[i].append(OpHessianOfGaussianEigenvaluesFF(self))
                     else:
                         oparray[i].append(OpHessianOfGaussianEigenvalues(self))
@@ -267,7 +265,7 @@ class OpPixelFeaturesPresmoothed(Operator):
 
             elif featureId == 'GaussianGradientMagnitude':
                 for j in range(dimCol):
-                    if self.withFastFilters.value:
+                    if WITH_FAST_FILTERS:
                         oparray[i].append(OpGaussianGradientMagnitudeFF(self))
                     else:
                         oparray[i].append(OpGaussianGradientMagnitude(self))
@@ -277,7 +275,7 @@ class OpPixelFeaturesPresmoothed(Operator):
 
             elif featureId == 'DifferenceOfGaussians':
                 for j in range(dimCol):
-                    if self.withFastFilters.value:
+                    if WITH_FAST_FILTERS:
                         oparray[i].append(OpDifferenceOfGaussiansFF(self))
                     else:
                         oparray[i].append(OpDifferenceOfGaussians(self))
@@ -546,7 +544,7 @@ class OpPixelFeaturesPresmoothed(Operator):
                             droi = (tuple(vigOpSourceStart._asint()), tuple(vigOpSourceStop._asint()))
                             tmp_key = getAllExceptAxis(len(sourceArraysForSigmas[j].shape),timeAxis, i)
                             
-                            if self.withFastFilters.value:
+                            if WITH_FAST_FILTERS:
                                 vsa  = vigra.taggedView( numpy.ascontiguousarray(vsa), vsa.axistags )
                                 buffer = fastfilters.gaussianSmoothing(vsa, tempSigma, window_size = self.WINDOW_SIZE )
                                 droi = roiToSlice(*droi)
@@ -557,7 +555,7 @@ class OpPixelFeaturesPresmoothed(Operator):
                     else:
                         droi = (tuple(vigOpSourceStart._asint()), tuple(vigOpSourceStop._asint()))
                         
-                        if self.withFastFilters.value:
+                        if WITH_FAST_FILTERS:
                             sourceArrayV = vigra.taggedView( numpy.ascontiguousarray(sourceArrayV), sourceArrayV.axistags )
                             buffer = fastfilters.gaussianSmoothing(sourceArrayV, tempSigma, window_size = self.WINDOW_SIZE )                                       
                             droi = roiToSlice(*droi)

--- a/lazyflow/operators/vigraOperators.py
+++ b/lazyflow/operators/vigraOperators.py
@@ -632,7 +632,7 @@ class OpPixelFeaturesPresmoothed(Operator):
             if vol.channels > 1:
                 result = numpy.zeros(vol.shape).astype(vol.dtype)
                 chInd = vol.channelIndex
-                chSlice = [slice(None) for dim in range(len(vsa.shape))]
+                chSlice = [slice(None) for dim in range(len(vol.shape))]
                 
                 for channel in range(vol.channels):
                     chSlice[chInd] = slice(channel, channel+1)

--- a/lazyflow/operators/vigraOperators.py
+++ b/lazyflow/operators/vigraOperators.py
@@ -545,7 +545,6 @@ class OpPixelFeaturesPresmoothed(Operator):
                             tmp_key = getAllExceptAxis(len(sourceArraysForSigmas[j].shape),timeAxis, i)
                             
                             if WITH_FAST_FILTERS:
-                                vsa  = vigra.taggedView( numpy.ascontiguousarray(vsa), vsa.axistags )
                                 buffer = fastfilters.gaussianSmoothing(vsa, tempSigma, window_size = self.WINDOW_SIZE )
                                 droi = roiToSlice(*droi)
                                 sourceArraysForSigmas[j][tmp_key] = buffer[droi]
@@ -556,7 +555,6 @@ class OpPixelFeaturesPresmoothed(Operator):
                         droi = (tuple(vigOpSourceStart._asint()), tuple(vigOpSourceStop._asint()))
                         
                         if WITH_FAST_FILTERS:
-                            sourceArrayV = vigra.taggedView( numpy.ascontiguousarray(sourceArrayV), sourceArrayV.axistags )
                             buffer = fastfilters.gaussianSmoothing(sourceArrayV, tempSigma, window_size = self.WINDOW_SIZE )                                       
                             droi = roiToSlice(*droi)
                             sourceArraysForSigmas[j] = buffer[droi]
@@ -1489,7 +1487,6 @@ class OpDifferenceOfGaussiansFF(OpBaseVigraFilter):
     name = "DifferenceOfGaussiansFF"
     
     def differenceOfGausssiansFF(image, sigma0, sigma1, window_size):
-        image = vigra.taggedView( numpy.ascontiguousarray(image), image.axistags )
         return (fastfilters.gaussianSmoothing(image, sigma0, window_size) - fastfilters.gaussianSmoothing(image, sigma1, window_size) )
     
     vigraFilter = staticmethod(differenceOfGausssiansFF)
@@ -1521,11 +1518,7 @@ class OpDifferenceOfGaussians(OpBaseVigraFilter):
 class OpGaussianSmoothingFF(OpBaseVigraFilter):
     name = "GaussianSmoothingFF"
 
-    def gaussianSmoothingFF(image, sigma, window_size):
-        image = vigra.taggedView( numpy.ascontiguousarray(image), image.axistags )
-        return fastfilters.gaussianSmoothing(image, sigma, window_size)
-
-    vigraFilter =  staticmethod(gaussianSmoothingFF)
+    vigraFilter =  staticmethod(fastfilters.gaussianSmoothing)
        
     outputDtype = numpy.float32
     supportsRoi = False
@@ -1550,12 +1543,8 @@ class OpGaussianSmoothing(OpBaseVigraFilter):
 
 class OpHessianOfGaussianEigenvaluesFF(OpBaseVigraFilter):
     name = "HessianOfGaussianEigenvaluesFF"
-
-    def hessianOfGaussianEigenvaluesFF(image, scale, window_size):
-        image = vigra.taggedView( numpy.ascontiguousarray(image), image.axistags )
-        return fastfilters.hessianOfGaussianEigenvalues(image, scale, window_size)
     
-    vigraFilter = staticmethod(hessianOfGaussianEigenvaluesFF)
+    vigraFilter = staticmethod(fastfilters.hessianOfGaussianEigenvalues)
     
     outputDtype = numpy.float32
     supportsRoi = False
@@ -1586,11 +1575,7 @@ class OpHessianOfGaussianEigenvalues(OpBaseVigraFilter):
 class OpStructureTensorEigenvaluesFF(OpBaseVigraFilter):
     name = "StructureTensorEigenvaluesFF"
 
-    def structureTensorEigenvaluesFF(image, innerScale, outerScale, window_size):
-        image = vigra.taggedView( numpy.ascontiguousarray(image), image.axistags )
-        return fastfilters.structureTensorEigenvalues(image, innerScale, outerScale, window_size)
-    
-    vigraFilter = staticmethod(structureTensorEigenvaluesFF)
+    vigraFilter = staticmethod(fastfilters.structureTensorEigenvalues)
     
     outputDtype = numpy.float32
     supportsRoi = False
@@ -1649,11 +1634,7 @@ class OpHessianOfGaussian(OpBaseVigraFilter):
 class OpGaussianGradientMagnitudeFF(OpBaseVigraFilter):
     name = "GaussianGradientMagnitudeFF"
 
-    def gaussianGradientMagnitudeFF(image, sigma, window_size):
-        image = vigra.taggedView( numpy.ascontiguousarray(image), image.axistags )
-        return fastfilters.gaussianGradientMagnitude(image, sigma, window_size)
-    
-    vigraFilter = staticmethod(gaussianGradientMagnitudeFF)
+    vigraFilter = staticmethod(fastfilters.gaussianGradientMagnitude)
     
     outputDtype = numpy.float32
     supportsRoi = False
@@ -1681,11 +1662,7 @@ class OpGaussianGradientMagnitude(OpBaseVigraFilter):
 class OpLaplacianOfGaussianFF(OpBaseVigraFilter):
     name = "LaplacianOfGaussianFF"
     
-    def laplacianOfGaussianFF(image, scale, window_size):
-        image = vigra.taggedView( numpy.ascontiguousarray(image), image.axistags )
-        return fastfilters.laplacianOfGaussian(image, scale, window_size)
-    
-    vigraFilter = staticmethod(laplacianOfGaussianFF)
+    vigraFilter = staticmethod(fastfilters.laplacianOfGaussian)
     
     outputDtype = numpy.float32
     supportsOut = False

--- a/lazyflow/operators/vigraOperators.py
+++ b/lazyflow/operators/vigraOperators.py
@@ -1387,8 +1387,9 @@ class OpBaseVigraFilter(OpArrayPiper):
                         try:
                             temp = self.vigraFilter(image, **kwparams)
                         except Exception, e:
-                            logger.error( "EXCEPT 2.2 {} {} {} {}".format( self.name, image.shape, kwparams ) )
+                            logger.error( "EXCEPT 2.2 {} {} {}".format( self.name, image.shape, kwparams ) )
                             traceback.print_exc(e)
+                            import sys
                             sys.exit(1)
                         temp=temp[writeKey]
 

--- a/lazyflow/operators/vigraOperators.py
+++ b/lazyflow/operators/vigraOperators.py
@@ -1188,11 +1188,11 @@ def getAllExceptAxis(ndim,index,slicer):
     res[index] = slicer
     return tuple(res)
 
-class OpBaseVigraFilter(OpArrayPiper):
+class OpBaseFilter(OpArrayPiper):
     inputSlots = [InputSlot("Input"), InputSlot("sigma", stype = "float")]
     outputSlots = [OutputSlot("Output")]
 
-    name = "OpBaseVigraFilter"
+    name = "OpBaseFilter"
     category = "Vigra filter"
 
     vigraFilter = None
@@ -1481,7 +1481,7 @@ def coherenceOrientationOfStructureTensor(image,sigma0, sigma1, window_size, out
     return res
 
 
-class OpDifferenceOfGaussians(OpBaseVigraFilter):
+class OpDifferenceOfGaussians(OpBaseFilter):
     outputDtype = numpy.float32
     supportsOut = False
     supportsWindow = True
@@ -1506,7 +1506,7 @@ class OpDifferenceOfGaussians(OpBaseVigraFilter):
         vigraFilter = staticmethod(differenceOfGausssians)
 
 
-class OpGaussianSmoothing(OpBaseVigraFilter):
+class OpGaussianSmoothing(OpBaseFilter):
     outputDtype = numpy.float32
     supportsWindow = True
     
@@ -1527,7 +1527,7 @@ class OpGaussianSmoothing(OpBaseVigraFilter):
         vigraFilter = staticmethod(vigra.filters.gaussianSmoothing)
         
 
-class OpHessianOfGaussianEigenvalues(OpBaseVigraFilter):
+class OpHessianOfGaussianEigenvalues(OpBaseFilter):
     outputDtype = numpy.float32
     supportsWindow = True
     
@@ -1551,7 +1551,7 @@ class OpHessianOfGaussianEigenvalues(OpBaseVigraFilter):
         vigraFilter = staticmethod(vigra.filters.hessianOfGaussianEigenvalues)
         
 
-class OpStructureTensorEigenvalues(OpBaseVigraFilter):
+class OpStructureTensorEigenvalues(OpBaseFilter):
     outputDtype = numpy.float32
     supportsWindow = True
     
@@ -1575,7 +1575,7 @@ class OpStructureTensorEigenvalues(OpBaseVigraFilter):
         vigraFilter = staticmethod(vigra.filters.structureTensorEigenvalues)
 
 
-class OpHessianOfGaussianEigenvaluesFirst(OpBaseVigraFilter):
+class OpHessianOfGaussianEigenvaluesFirst(OpBaseFilter):
     name = "First Eigenvalue of Hessian Matrix"
     vigraFilter = staticmethod(firstHessianOfGaussianEigenvalues)
     outputDtype = numpy.float32
@@ -1589,7 +1589,7 @@ class OpHessianOfGaussianEigenvaluesFirst(OpBaseVigraFilter):
         return 1
 
 
-class OpHessianOfGaussian(OpBaseVigraFilter):
+class OpHessianOfGaussian(OpBaseFilter):
     name = "HessianOfGaussian"
     vigraFilter = staticmethod(vigra.filters.hessianOfGaussian)
     outputDtype = numpy.float32
@@ -1602,7 +1602,7 @@ class OpHessianOfGaussian(OpBaseVigraFilter):
         return temp
     
 
-class OpGaussianGradientMagnitude(OpBaseVigraFilter):
+class OpGaussianGradientMagnitude(OpBaseFilter):
     outputDtype = numpy.float32
     supportsWindow = True
     
@@ -1623,7 +1623,7 @@ class OpGaussianGradientMagnitude(OpBaseVigraFilter):
         vigraFilter = staticmethod(vigra.filters.gaussianGradientMagnitude)
 
 
-class OpLaplacianOfGaussian(OpBaseVigraFilter):
+class OpLaplacianOfGaussian(OpBaseFilter):
     outputDtype = numpy.float32
     supportsWindow = True
     

--- a/lazyflow/operators/vigraOperators.py
+++ b/lazyflow/operators/vigraOperators.py
@@ -1497,128 +1497,97 @@ def coherenceOrientationOfStructureTensor(image,sigma0, sigma1, window_size, out
 
 
 class OpDifferenceOfGaussians(OpBaseVigraFilter):
+    outputDtype = numpy.float32
+    supportsOut = False
+    supportsWindow = True
+    
+    def resultingChannels(self):
+        return 1
+    
+    inputSlots = [InputSlot("Input"), InputSlot("sigma0", stype = "float"), InputSlot("sigma1", stype = "float")]
+    
     if WITH_FAST_FILTERS:
         name = "DifferenceOfGaussiansFF"
+        supportsRoi = False
         
         def differenceOfGausssiansFF(image, sigma0, sigma1, window_size):
             return (fastfilters.gaussianSmoothing(image, sigma0, window_size) - fastfilters.gaussianSmoothing(image, sigma1, window_size) )
         
         vigraFilter = staticmethod(differenceOfGausssiansFF)
-        
-        outputDtype = numpy.float32
-        supportsOut = False
-        supportsWindow = True
-        supportsRoi = False
-        inputSlots = [InputSlot("Input"), InputSlot("sigma0", stype = "float"), InputSlot("sigma1", stype = "float")]
-    
-        def resultingChannels(self):
-            return 1
-    
     else:
         name = "DifferenceOfGaussians"
+        supportsRoi = True
         
         vigraFilter = staticmethod(differenceOfGausssians)
-        
-        outputDtype = numpy.float32
-        supportsOut = False
-        supportsWindow = True
-        supportsRoi = True
-        inputSlots = [InputSlot("Input"), InputSlot("sigma0", stype = "float"), InputSlot("sigma1", stype = "float")]
-    
-        def resultingChannels(self):
-            return 1
 
 
 class OpGaussianSmoothing(OpBaseVigraFilter):
+    outputDtype = numpy.float32
+    supportsWindow = True
+    
+    def resultingChannels(self):
+        return 1
+    
     if WITH_FAST_FILTERS:
         name = "GaussianSmoothingFF"
-
-        vigraFilter =  staticmethod(fastfilters.gaussianSmoothing)
-           
-        outputDtype = numpy.float32
         supportsRoi = False
-        supportsWindow = True
-        supportsOut = False
-        
-        def resultingChannels(self):
-            return 1
-        
+        supportsOut = False 
+
+        vigraFilter =  staticmethod(fastfilters.gaussianSmoothing)  
     else:
         name = "GaussianSmoothing"
+        supportsRoi = True
+        supportsOut = True
                 
         vigraFilter = staticmethod(vigra.filters.gaussianSmoothing)
-           
-        outputDtype = numpy.float32
-        supportsRoi = True
-        supportsWindow = True
-        supportsOut = True
         
-        def resultingChannels(self):
-            return 1
-
 
 class OpHessianOfGaussianEigenvalues(OpBaseVigraFilter):
+    outputDtype = numpy.float32
+    supportsWindow = True
+    
+    def resultingChannels(self):
+        temp = self.inputs["Input"].meta.axistags.axisTypeCount(vigra.AxisType.Space)
+        return temp
+    
+    inputSlots = [InputSlot("Input"), InputSlot("scale", stype = "float")]
+    
     if WITH_FAST_FILTERS:
         name = "HessianOfGaussianEigenvaluesFF"
-        
-        vigraFilter = staticmethod(fastfilters.hessianOfGaussianEigenvalues)
-        
-        outputDtype = numpy.float32
         supportsRoi = False
-        supportsWindow = True
-        supportsOut = False
-        inputSlots = [InputSlot("Input"), InputSlot("scale", stype = "float")]
+        supportsOut = False 
         
-        def resultingChannels(self):
-            temp = self.inputs["Input"].meta.axistags.axisTypeCount(vigra.AxisType.Space)
-            return temp        
-        
+        vigraFilter = staticmethod(fastfilters.hessianOfGaussianEigenvalues)   
     else:
         name = "HessianOfGaussianEigenvalues"
+        supportsRoi = True
+        supportsOut = True
         
         vigraFilter = staticmethod(vigra.filters.hessianOfGaussianEigenvalues)
         
-        outputDtype = numpy.float32
-        supportsRoi = True
-        supportsWindow = True
-        supportsOut = True
-        inputSlots = [InputSlot("Input"), InputSlot("scale", stype = "float")]
-        
-        def resultingChannels(self):
-            temp = self.inputs["Input"].meta.axistags.axisTypeCount(vigra.AxisType.Space)
-            return temp
-
 
 class OpStructureTensorEigenvalues(OpBaseVigraFilter):
+    outputDtype = numpy.float32
+    supportsWindow = True
+    
+    def resultingChannels(self):
+        temp = self.inputs["Input"].meta.axistags.axisTypeCount(vigra.AxisType.Space)
+        return temp
+    
+    inputSlots = [InputSlot("Input"), InputSlot("innerScale", stype = "float"),InputSlot("outerScale", stype = "float")]
+    
     if WITH_FAST_FILTERS:
         name = "StructureTensorEigenvaluesFF"
-    
-        vigraFilter = staticmethod(fastfilters.structureTensorEigenvalues)
-        
-        outputDtype = numpy.float32
         supportsRoi = False
-        supportsWindow = True
         supportsOut = False
-        inputSlots = [InputSlot("Input"), InputSlot("innerScale", stype = "float"),InputSlot("outerScale", stype = "float")]
     
-        def resultingChannels(self):
-            temp = self.inputs["Input"].meta.axistags.axisTypeCount(vigra.AxisType.Space)
-            return temp
-    
+        vigraFilter = staticmethod(fastfilters.structureTensorEigenvalues)    
     else: 
         name = "StructureTensorEigenvalues"
+        supportsRoi = True
+        supportsOut = True
         
         vigraFilter = staticmethod(vigra.filters.structureTensorEigenvalues)
-        
-        outputDtype = numpy.float32
-        supportsRoi = True
-        supportsWindow = True
-        supportsOut = True
-        inputSlots = [InputSlot("Input"), InputSlot("innerScale", stype = "float"),InputSlot("outerScale", stype = "float")]
-    
-        def resultingChannels(self):
-            temp = self.inputs["Input"].meta.axistags.axisTypeCount(vigra.AxisType.Space)
-            return temp
 
 
 class OpHessianOfGaussianEigenvaluesFirst(OpBaseVigraFilter):
@@ -1649,61 +1618,47 @@ class OpHessianOfGaussian(OpBaseVigraFilter):
     
 
 class OpGaussianGradientMagnitude(OpBaseVigraFilter):
+    outputDtype = numpy.float32
+    supportsWindow = True
+    
+    def resultingChannels(self):
+        return 1
+    
     if WITH_FAST_FILTERS:
         name = "GaussianGradientMagnitudeFF"
-    
-        vigraFilter = staticmethod(fastfilters.gaussianGradientMagnitude)
-        
-        outputDtype = numpy.float32
         supportsRoi = False
-        supportsWindow = True
         supportsOut = False
     
-        def resultingChannels(self):
-            return 1
-    
+        vigraFilter = staticmethod(fastfilters.gaussianGradientMagnitude)
     else:
         name = "GaussianGradientMagnitude"
-        
-        vigraFilter = staticmethod(vigra.filters.gaussianGradientMagnitude)
-        
-        outputDtype = numpy.float32
         supportsRoi = True
-        supportsWindow = True
         supportsOut = True
         
-        def resultingChannels(self):
-            return 1
+        vigraFilter = staticmethod(vigra.filters.gaussianGradientMagnitude)
 
 
 class OpLaplacianOfGaussian(OpBaseVigraFilter):
+    outputDtype = numpy.float32
+    supportsWindow = True
+    
+    def resultingChannels(self):
+        return 1
+    
+    inputSlots = [InputSlot("Input"), InputSlot("scale", stype = "float")]
+    
     if WITH_FAST_FILTERS:
         name = "LaplacianOfGaussianFF"
-        
-        vigraFilter = staticmethod(fastfilters.laplacianOfGaussian)
-        
-        outputDtype = numpy.float32
         supportsOut = False
         supportsRoi = False
-        supportsWindow = True
-        inputSlots = [InputSlot("Input"), InputSlot("scale", stype = "float")]
-    
-        def resultingChannels(self):
-            return 1
-    
+        
+        vigraFilter = staticmethod(fastfilters.laplacianOfGaussian)
     else:
         name = "LaplacianOfGaussian"
-        
-        vigraFilter = staticmethod(vigra.filters.laplacianOfGaussian)
-        
-        outputDtype = numpy.float32
         supportsOut = True
         supportsRoi = True
-        supportsWindow = True
-        inputSlots = [InputSlot("Input"), InputSlot("scale", stype = "float")]
-    
-        def resultingChannels(self):
-            return 1
+        
+        vigraFilter = staticmethod(vigra.filters.laplacianOfGaussian)
 
 
 class OpImageReader(Operator):


### PR DESCRIPTION
Integrated @svenpeter42 fast filters into Ilastik. Some points worth noting:

* Sven's filters are only supported on Linux and Mac.
* The code includes wrappers for each filter that check for contiguous arrays, and make sure that vigra arrays are being passed.
* `OpPixelFeaturesPresmoothed` includes a slot to enable/disable the fast filters in case that we need to do this manually for debugging purposes.