### PR TITLE
Hdf5 Cache

### DIFF
--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -422,9 +422,7 @@ class Operator(object):
         @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
             with self._condition:
-                # TODO: verify what the correct test should be
-                # while self._executionCount > 0:
-                while self._executionCount > 1:
+                while self._executionCount > 0:
                     self._condition.wait()
                 self._settingUp = True
 

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -422,7 +422,9 @@ class Operator(object):
         @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
             with self._condition:
-                while self._executionCount > 0:
+                # TODO: verify what the correct test should be
+                # while self._executionCount > 0:
+                while self._executionCount > 1:
                     self._condition.wait()
                 self._settingUp = True
 

--- a/lazyflow/operators/ioOperators/opFormattedDataExport.py
+++ b/lazyflow/operators/ioOperators/opFormattedDataExport.py
@@ -30,8 +30,13 @@ from lazyflow.roi import roiFromShape
 from lazyflow.operators.generic import OpSubRegion, OpPixelOperator
 from lazyflow.operators.valueProviders import OpMetadataInjector
 from lazyflow.operators.opReorderAxes import OpReorderAxes
+from lazyflow.utility.timer import timeLogged
 
 from .opExportSlot import OpExportSlot
+
+import logging
+logger = logging.getLogger(__name__)
+
 
 class OpFormattedDataExport(Operator):
     """
@@ -228,8 +233,10 @@ class OpFormattedDataExport(Operator):
     def propagateDirty(self, slot, subindex, roi):
         self._dirty = True
 
+    @timeLogged(logger, logging.INFO)
     def run_export(self):
         self._opExportSlot.run_export()
 
+    @timeLogged(logger, logging.INFO)
     def run_export_to_array(self):
         return self._opExportSlot.run_export_to_array()

--- a/lazyflow/operators/opBlockedHdf5Cache.py
+++ b/lazyflow/operators/opBlockedHdf5Cache.py
@@ -1,0 +1,83 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#          http://ilastik.org/license/
+###############################################################################
+
+import copy
+
+from lazyflow.graph import Operator, InputSlot, OutputSlot
+from lazyflow.utility import RamMeasurementContext
+
+from opCacheFixer import OpCacheFixer
+from opUnblockedHdf5Cache import OpUnblockedHdf5Cache
+from opSplitRequestsBlockwise import OpSplitRequestsBlockwise
+
+class OpBlockedHdf5Cache(Operator):
+    """
+    A blockwise array cache, similar to OpBlockedArrayCache, but all data is stored in an open HDF5 group,
+    not in numpy arrays.  
+    Instead of a monolithic implementation, this operator is a small pipeline of three simple operators.
+    
+    The actual caching of data is handled by an unblocked cache, so the "blocked" functionality is 
+    implemented via separate "splitting" operator that comes after the cache.
+    Also, the "fixAtCurrent" feature is implemented in a special operator, which comes before the cache.    
+    """
+    fixAtCurrent = InputSlot(value=False)
+    Input = InputSlot()
+    H5CacheGroup = InputSlot()
+    #BlockShape = InputSlot()
+    innerBlockShape = InputSlot(optional=True)
+    outerBlockShape = InputSlot()
+    
+    Output = OutputSlot()
+    
+    def __init__(self, *args, **kwargs):
+        super( OpBlockedHdf5Cache, self ).__init__(*args, **kwargs)
+        
+        # Input ---------> opCacheFixer -> opUnblockedHdf5Cache -> opSplitRequestsBlockwise -> Output
+        #                 /               /                        /
+        # fixAtCurrent ---               /                        /
+        #                               /                        /
+        # H5CacheGroup -----------------                        /
+        #                                                      /
+        # BlockShape ------------------------------------------
+        
+        self._opCacheFixer = OpCacheFixer( parent=self )
+        self._opCacheFixer.Input.connect( self.Input )
+        self._opCacheFixer.fixAtCurrent.connect( self.fixAtCurrent )
+
+        self._opUnblockedHdf5Cache = OpUnblockedHdf5Cache( None, parent=self )
+        self._opUnblockedHdf5Cache.Input.connect( self._opCacheFixer.Output )
+        self._opUnblockedHdf5Cache.H5CacheGroup.connect( self.H5CacheGroup )
+
+        self._opSplitRequestsBlockwise = OpSplitRequestsBlockwise( always_request_full_blocks=True, parent=self )
+        self._opSplitRequestsBlockwise.BlockShape.connect( self.outerBlockShape )
+        self._opSplitRequestsBlockwise.Input.connect( self._opUnblockedHdf5Cache.Output )
+
+        self.Output.connect( self._opSplitRequestsBlockwise.Output )
+
+    def setupOutputs(self):
+        pass
+
+    def execute(self, slot, subindex, roi, result):
+        assert False, "Shouldn't get here."
+
+    def propagateDirty(self, slot, subindex, roi):
+        pass

--- a/lazyflow/operators/opUnblockedHdf5Cache.py
+++ b/lazyflow/operators/opUnblockedHdf5Cache.py
@@ -130,20 +130,25 @@ class OpUnblockedHdf5Cache(Operator):
                                                       **self._dataset_kwargs )
 
     def propagateDirty(self, slot, subindex, roi):
-        dirty_roi = self._standardize_roi( roi.start, roi.stop )
         maximum_roi = roiFromShape(self.Input.meta.shape)
-        maximum_roi = self._standardize_roi( *maximum_roi )
-        
-        if dirty_roi == maximum_roi:
-            # Optimize the common case:
-            # Everything is dirty, so no need to loop
-            self._clear_blocks()
-        else:
-            # FIXME: This is O(N) for now.
-            #        We should speed this up by maintaining a bookkeeping data structure in execute().
-            for block_roi_str in self._h5group.keys():
-                block_roi = eval(block_roi_str)
-                if getIntersection(block_roi, dirty_roi, assertIntersect=False):
-                    del self._h5group[block_roi_str]
 
-        self.Output.setDirty( roi.start, roi.stop )
+        if slot == self.Input:
+            maximum_roi = self._standardize_roi( *maximum_roi )
+            dirty_roi = self._standardize_roi( roi.start, roi.stop )
+
+            if dirty_roi == maximum_roi:
+                # Optimize the common case:
+                # Everything is dirty, so no need to loop
+                self._clear_blocks()
+            else:
+                # FIXME: This is O(N) for now.
+                #        We should speed this up by maintaining a bookkeeping data structure in execute().
+                for block_roi_str in self._h5group.keys():
+                    block_roi = eval(block_roi_str)
+                    if getIntersection(block_roi, dirty_roi, assertIntersect=False):
+                        del self._h5group[block_roi_str]
+
+            self.Output.setDirty( roi )
+        else:
+            self.Output.setDirty( slice(None) )
+

--- a/lazyflow/operators/opUnblockedHdf5Cache.py
+++ b/lazyflow/operators/opUnblockedHdf5Cache.py
@@ -66,11 +66,6 @@ class OpUnblockedHdf5Cache(Operator):
         stop = tuple(map(int, stop))        
         return (start, stop)
 
-    @classmethod
-    def roi_str(cls, start, stop):
-        roi = cls._standardize_roi(start, stop)
-        return str(roi_str)
-
     def setupOutputs(self):
         with self._lock:
             self._h5group = self.H5CacheGroup.value

--- a/lazyflow/operators/opUnblockedHdf5Cache.py
+++ b/lazyflow/operators/opUnblockedHdf5Cache.py
@@ -1,0 +1,149 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+#           http://ilastik.org/license/
+###############################################################################
+
+import time
+import collections
+import numpy
+
+from lazyflow.graph import Operator, InputSlot, OutputSlot
+from lazyflow.request import RequestLock
+from lazyflow.roi import getIntersection, roiFromShape, roiToSlice, containing_rois
+
+import logging
+logger = logging.getLogger(__name__)
+
+class OpUnblockedHdf5Cache(Operator):
+    """
+    This cache operator stores the results of all requests that pass through 
+    it, in exactly the same blocks that were requested.
+
+    - If there are any overlapping requests, then the data for the overlapping portion will 
+        be stored multiple times, except for the special case where the new request happens 
+        to fall ENTIRELY within an existing block of data.
+    - If any portion of a stored block is marked dirty, the entire block is discarded.
+
+    Unlike other caches, this cache does not impose its own blocking on the data.
+    Instead, it is assumed that the downstream operators have chosen some reasonable blocking.
+    Hopefully the downstream operators are reasonably consistent in the blocks they request data with,
+    since every unique result is cached separately.
+    """
+    Input = InputSlot()
+    H5CacheGroup = InputSlot()
+    Output = OutputSlot()
+    
+    def __init__(self, dataset_kwargs, *args, **kwargs):
+        super( OpUnblockedHdf5Cache, self ).__init__(*args, **kwargs)
+        self._lock = RequestLock()
+        self._h5group = None
+        dataset_kwargs = dataset_kwargs or { 'compression' : 'lzf' }
+        self._dataset_kwargs = dataset_kwargs
+        self._block_locks = {}
+
+    @classmethod
+    def _standardize_roi(cls, start, stop):
+        # We use rois as dict keys.
+        # For comparison purposes, all rois in the dict keys are assumed to be tuple-of-tuples-of-int
+        start = tuple(map(int, start))
+        stop = tuple(map(int, stop))        
+        return (start, stop)
+
+    @classmethod
+    def roi_str(cls, start, stop):
+        roi = cls._standardize_roi(start, stop)
+        return str(roi_str)
+
+    def setupOutputs(self):
+        with self._lock:
+            self._h5group = self.H5CacheGroup.value
+        self.Output.meta.assignFrom(self.Input.meta)
+    
+    def _clear_blocks(self):
+        keys = self._h5group.keys()
+        for k in keys:
+            del self._h5group[k]
+        self._block_locks = {}
+
+    def execute(self, slot, subindex, roi, result):
+        with self._lock:
+            # Does this roi happen to fit ENTIRELY within an existing stored block?
+            block_rois = map( eval, self._h5group.keys() )
+            outer_rois = containing_rois( block_rois, (roi.start, roi.stop) )
+            if len(outer_rois) > 0:
+                # Use the first one we found
+                block_roi = self._standardize_roi( *outer_rois[0] )
+                block_relative_roi = numpy.array( (roi.start, roi.stop) ) - block_roi[0]
+                
+                self.Output.stype.copy_data(result, self._h5group[str(block_roi)][ roiToSlice(*block_relative_roi) ])
+                return
+                
+        # Standardize roi for usage as dict key
+        block_roi = self._standardize_roi( roi.start, roi.stop )
+        
+        # Get lock for this block (create first if necessary)
+        with self._lock:
+            if block_roi not in self._block_locks:
+                self._block_locks[block_roi] = RequestLock()
+            block_lock = self._block_locks[block_roi]
+
+        # Handle identical simultaneous requests
+        with block_lock:
+            if str(block_roi) in self._h5group:
+                self.Output.stype.copy_data(result, self._h5group[str(block_roi)])
+                return
+            else: # Not yet stored: Request it now.
+                # We attach a special attribute to the array to allow the upstream operator
+                #  to optionally tell us not to bother caching the data.
+                self.Input(roi.start, roi.stop).writeInto(result).block()
+
+                if self.Input.meta.dontcache:
+                    # The upstream operator says not to bother caching the data.
+                    # (For example, see OpCacheFixer.)
+                    return
+                
+                with self._lock:
+                    # Store the data.
+                    # First double-check that the block wasn't removed from the 
+                    #   cache while we were requesting it. 
+                    # (Could have happened via propagateDirty() or eventually the arrayCacheMemoryMgr)
+                    if block_roi in self._block_locks:
+                        self._h5group.create_dataset( str(block_roi),
+                                                      data=result,
+                                                      **self._dataset_kwargs )
+
+    def propagateDirty(self, slot, subindex, roi):
+        dirty_roi = self._standardize_roi( roi.start, roi.stop )
+        maximum_roi = roiFromShape(self.Input.meta.shape)
+        maximum_roi = self._standardize_roi( *maximum_roi )
+        
+        if dirty_roi == maximum_roi:
+            # Optimize the common case:
+            # Everything is dirty, so no need to loop
+            self._clear_blocks()
+        else:
+            # FIXME: This is O(N) for now.
+            #        We should speed this up by maintaining a bookkeeping data structure in execute().
+            for block_roi_str in self._h5group.keys():
+                block_roi = eval(block_roi_str)
+                if getIntersection(block_roi, dirty_roi, assertIntersect=False):
+                    del self._h5group[block_roi_str]
+
+        self.Output.setDirty( roi.start, roi.stop )

--- a/lazyflow/rtype.py
+++ b/lazyflow/rtype.py
@@ -130,7 +130,7 @@ class SubRegion(Roi):
 
         for start, stop in zip(self.start, self.stop):
             assert isinstance(start, (int, long, numpy.integer)), "Roi contains non-integers: {}".format( self )
-            assert isinstance(start, (int, long, numpy.integer)), "Roi contains non-integers: {}".format( self )
+            assert isinstance(stop, (int, long, numpy.integer)), "Roi contains non-integers: {}".format( self )
 
 # FIXME: This assertion is good at finding bugs, but it is currently triggered by 
 #        the DataExport applet when the output axis order is changed. 

--- a/tests/testOpUblockedHdf5Cache.py
+++ b/tests/testOpUblockedHdf5Cache.py
@@ -1,0 +1,94 @@
+import tempfile
+import shutil
+import numpy as np
+import h5py
+import vigra
+
+import logging
+logger = logging.getLogger( __name__ )
+cacheLogger = logging.getLogger( "lazyflow.operators.opUnblockedHdf5Cache" )
+
+class TestOpUnblockedHdf5Cache(object):
+    
+    def setUp(self):
+        h5py._errors.silence_errors()
+        self.testdir = tempfile.mkdtemp()
+        
+    def tearDown(self):
+        shutil.rmtree(self.testdir)
+    
+    def testBasic(self):
+        # late imports so monkey-patch code still works
+        from lazyflow.request import RequestPool
+        from lazyflow.graph import Graph
+        from lazyflow.roi import roiToSlice
+        from lazyflow.operators.opUnblockedHdf5Cache import OpUnblockedHdf5Cache
+        from lazyflow.utility.testing import OpArrayPiperWithAccessCount
+
+        with h5py.File(self.testdir + '/cache.h5', 'w') as f_cache:        
+            graph = Graph()
+            opDataProvider = OpArrayPiperWithAccessCount( graph=graph )
+            opCache = OpUnblockedHdf5Cache( None, graph=graph )
+            opCache.H5CacheGroup.setValue(f_cache)
+            
+            data = np.random.random( (100,100,100) ).astype(np.float32)
+            opDataProvider.Input.setValue( vigra.taggedView( data, 'zyx' ) )
+            opCache.Input.connect( opDataProvider.Output )
+            
+            roi = ((30, 30, 30), (50, 50, 50))
+            cache_data = opCache.Output( *roi ).wait()
+            assert (cache_data == data[roiToSlice(*roi)]).all()
+            assert opDataProvider.accessCount == 1
+    
+            # Request the same data a second time.
+            # Access count should not change.
+            cache_data = opCache.Output( *roi ).wait()
+            assert (cache_data == data[roiToSlice(*roi)]).all()
+            assert opDataProvider.accessCount == 1
+            
+            # Now invalidate a part of the data
+            # The cache will discard it, so the access count should increase.
+            opDataProvider.Input.setDirty( (30, 30, 30), (31, 31, 31) )
+            cache_data = opCache.Output( *roi ).wait()
+            assert (cache_data == data[roiToSlice(*roi)]).all()
+            assert opDataProvider.accessCount == 2
+                    
+            # Repeat this next part just for safety
+            for _ in range(10):
+                # Make sure the cache is empty
+                opDataProvider.Input.setDirty( (30, 30, 30), (31, 31, 31) )
+                opDataProvider.accessCount = 0
+    
+                # Create many requests for the same data.
+                # Upstream data should only be accessed ONCE.
+                pool = RequestPool()
+                for _ in range(10):
+                    pool.add( opCache.Output( *roi ) )
+                pool.wait()
+                assert opDataProvider.accessCount == 1
+    
+            # Also, make sure requests for INNER rois of stored blocks are also serviced from memory
+            opDataProvider.accessCount = 0
+            inner_roi = ((35, 35, 35), (45, 45, 45))
+            cache_data = opCache.Output( *inner_roi ).wait()
+            assert (cache_data == data[roiToSlice(*inner_roi)]).all()
+            assert opDataProvider.accessCount == 0
+
+if __name__ == "__main__":
+    # Set up logging for debug
+    import sys
+    logHandler = logging.StreamHandler( sys.stdout )
+    logger.addHandler( logHandler )
+    cacheLogger.addHandler( logHandler )
+
+    logger.setLevel( logging.DEBUG )
+    cacheLogger.setLevel( logging.DEBUG )
+
+    # Run nose
+    import sys
+    import nose
+    sys.argv.append("--nocapture")    # Don't steal stdout.  Show it on the console as usual.
+    sys.argv.append("--nologcapture") # Don't set the logging level to DEBUG.  Leave it alone.
+    ret = nose.run(defaultTest=__file__)
+    if not ret: sys.exit(1)
+


### PR DESCRIPTION
This patch is based on h5-cache, but updated to sync with master.  The primary changes were made to opUnblockedHdf5Cache, making the locking simpler, and making propagate dirty work correctly.  It works with the ilastk/blockwise_carving patch.