### PR TITLE
Add npz support

### DIFF
--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -73,7 +73,7 @@ class OpInputDataReader(Operator):
     videoExts = ['ufmf', 'mmf', 'avi']
     h5Exts = ['h5', 'hdf5', 'ilp']
     klbExts = ['klb']
-    npyExts = ['npy']
+    npyExts = ['npy', 'npz']
     rawExts = ['dat', 'bin', 'raw']
     blockwiseExts = ['json']
     tiledExts = ['json']

--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -29,7 +29,7 @@ from opTiffSequenceReader import OpTiffSequenceReader
 from lazyflow.operators.ioOperators import OpStackLoader, OpBlockwiseFilesetReader, OpRESTfulBlockwiseFilesetReader, \
     OpCachedTiledVolumeReader, OpKlbReader
 from lazyflow.utility.jsonConfig import JsonConfigParser
-from lazyflow.utility.pathHelpers import isUrl
+from lazyflow.utility.pathHelpers import isUrl, PathComponents
 
 from opStreamingUfmfReader import OpStreamingUfmfReader
 from opStreamingMmfReader import OpStreamingMmfReader
@@ -361,20 +361,28 @@ class OpInputDataReader(Operator):
         return dataset_names
 
     def _attemptOpenAsNpy(self, filePath):
-        fileExtension = os.path.splitext(filePath)[1].lower()
-        fileExtension = fileExtension.lstrip('.') # Remove leading dot
-
-        # Check for numpy extension
-        if fileExtension not in OpInputDataReader.npyExts:
+        pathComponents = PathComponents(filePath)
+        ext = pathComponents.extension
+        if ext not in (".%s" % x for x in OpInputDataReader.npyExts):
             return ([], None)
-        else:
-            try:
-                # Create an internal operator
-                npyReader = OpNpyFileReader(parent=self)
-                npyReader.FileName.setValue(filePath)
-                return ([npyReader], npyReader.Output)
-            except OpNpyFileReader.DatasetReadError as e:
-                raise OpInputDataReader.DatasetReadError( *e.args )
+
+        externalPath = pathComponents.externalPath
+        internalPath = pathComponents.internalPath
+        # FIXME: check whether path is valid?!
+
+        if not os.path.exists(externalPath):
+            raise OpInputDataReader.DatasetReadError("Input file does not exist: " + externalPath)
+
+        try:
+            # Create an internal operator
+            npyReader = OpNpyFileReader(parent=self)
+            if internalPath is not None:
+                internalPath = internalPath.replace('/', '')
+            npyReader.InternalPath.setValue(internalPath)
+            npyReader.FileName.setValue(externalPath)
+            return ([npyReader], npyReader.Output)
+        except OpNpyFileReader.DatasetReadError as e:
+            raise OpInputDataReader.DatasetReadError( *e.args )
 
     def _attemptOpenAsRawBinary(self, filePath):
         fileExtension = os.path.splitext(filePath)[1].lower()

--- a/lazyflow/utility/pathHelpers.py
+++ b/lazyflow/utility/pathHelpers.py
@@ -30,6 +30,7 @@ class PathComponents(object):
 
     # Only files with these extensions are allowed to have an 'internal' path
     HDF5_EXTS = ['.ilp', '.h5', '.hdf5']
+    NPZ_EXTS = ['.npz']
 
     def __init__(self, totalPath, cwd=None):
         """
@@ -65,7 +66,7 @@ class PathComponents(object):
         totalPath = totalPath.replace("\\","/")
 
         # For hdf5 paths, split into external, extension, and internal paths
-        for x in self.HDF5_EXTS:
+        for x in (self.HDF5_EXTS + self.NPZ_EXTS):
             if totalPath.find(x) > extIndex:
                 extIndex = totalPath.find(x)
                 ext = x

--- a/tests/testPathHelpers.py
+++ b/tests/testPathHelpers.py
@@ -44,6 +44,11 @@ class TestPathHelpers(object):
         assert components.extension == '.h5'
         assert components.internalPath == '/with/internal/path/to/data'
 
+        components = PathComponents('/some/external/path/to/file.npz_crazy_ext.npz/withInternalPathToData')
+        assert components.externalPath == '/some/external/path/to/file.npz_crazy_ext.npz'
+        assert components.extension == '.npz'
+        assert components.internalPath == '/withInternalPathToData'
+
         # Everything should work for URLs, too.
         components = PathComponents('http://somehost:8000/path/to/data/with.ext')
         assert components.externalPath == 'http://somehost:8000/path/to/data/with.ext'


### PR DESCRIPTION
Very basic support for numpy npz files added. Works for uncompressed and compressed npz archives. However, numpy doesn't offer memory mapping of npz files. So the whole array is loaded.