### PR TITLE
Added option to bypass cache to opLabelVolume

### DIFF
--- a/lazyflow/operators/opBlockedArrayCache.py
+++ b/lazyflow/operators/opBlockedArrayCache.py
@@ -74,7 +74,9 @@ class OpBlockedArrayCache(Operator, ManagedBlockedCache):
         self._opSimpleBlockedArrayCache.CompressionEnabled.connect( self.CompressionEnabled )
         self._opSimpleBlockedArrayCache.Input.connect( self._opCacheFixer.Output )
         self._opSimpleBlockedArrayCache.BlockShape.connect( self.outerBlockShape )
+        self._opSimpleBlockedArrayCache.BypassModeEnabled.connect( self.BypassModeEnabled )
         self.CleanBlocks.connect( self._opSimpleBlockedArrayCache.CleanBlocks )
+        self.Output.connect( self._opSimpleBlockedArrayCache.Output )
 
         # Instead of connecting our Output directly to our internal pipeline,
         # We manually forward the data via the execute() function,
@@ -95,13 +97,7 @@ class OpBlockedArrayCache(Operator, ManagedBlockedCache):
         self.Output.meta.assignFrom( self._opSimpleBlockedArrayCache.Output.meta )
 
     def execute(self, slot, subindex, roi, result):
-        assert slot is self.Output, "Requesting data from unknown output slot."
-        if self.BypassModeEnabled.value:
-            # Pass data directly from Input to Output
-            self.Input(roi.start, roi.stop).writeInto(result).wait()
-        else:
-            # Pass data from internal pipeline to Output
-            self._opSimpleBlockedArrayCache.Output(roi.start, roi.stop).writeInto(result).wait()
+        assert False, "Shouldn't get here"
 
     def propagateDirty(self, slot, subindex, roi):
         pass

--- a/lazyflow/operators/opLabelVolume.py
+++ b/lazyflow/operators/opLabelVolume.py
@@ -40,6 +40,9 @@ class OpLabelVolume(Operator):
     #TODO relax requirements (single value is already working)
     Background = InputSlot(optional=True)
 
+    # Bypass cache (for headless mode)
+    BypassModeEnabled = InputSlot(value=False)
+
     ## decide which CCL method to use
     #
     # currently available:
@@ -111,6 +114,7 @@ class OpLabelVolume(Operator):
 
         self._opLabel = self._labelOps[method](parent=self)
         self._opLabel.Input.connect(self._op5.Output)
+        self._opLabel.BypassModeEnabled.connect(self.BypassModeEnabled)
 
         # connect reordering operators
         self._op5_2.Input.connect(self._opLabel.Output)
@@ -176,6 +180,9 @@ class OpLabelingABC(Operator):
 
     ## background with axes 'txyzc', spatial axes must be singletons
     Background = InputSlot()
+    
+    # Bypass cache (for headless mode)
+    BypassModeEnabled = InputSlot(value=False)
 
     Output = OutputSlot()
     CachedOutput = OutputSlot()
@@ -195,6 +202,7 @@ class OpLabelingABC(Operator):
         super(OpLabelingABC, self).__init__(*args, **kwargs)
         self._cache = OpBlockedArrayCache(parent=self)
         self._cache.name = "OpLabelVolume.OutputCache"
+        self._cache.BypassModeEnabled.connect(self.BypassModeEnabled)
         self._cache.CompressionEnabled.setValue(True)
         self._cache.Input.connect(self.Output)
         self.CachedOutput.connect(self._cache.Output)

--- a/lazyflow/operators/opSimpleBlockedArrayCache.py
+++ b/lazyflow/operators/opSimpleBlockedArrayCache.py
@@ -9,6 +9,7 @@ from lazyflow.rtype import SubRegion
 
 class OpSimpleBlockedArrayCache(OpUnblockedArrayCache):
     BlockShape = InputSlot(optional=True)
+    BypassModeEnabled = InputSlot(value=False)
 
     def __init__(self, *args, **kwargs):
         super( OpSimpleBlockedArrayCache, self ).__init__(*args, **kwargs)
@@ -61,6 +62,14 @@ class OpSimpleBlockedArrayCache(OpUnblockedArrayCache):
             elif self.Input.meta.dontcache:
                 # Data isn't in the cache, but we don't need it in the cache anyway.
                 self.Input(*clipped_block_roi).writeInto(result[roiToSlice(*output_roi)]).block()
+            elif self.BypassModeEnabled.value:
+                full_block_data = self.Output.stype.allocateDestination( SubRegion(self.Output, *full_block_roi ) )
+
+                self.Input(*full_block_roi).writeInto(full_block_data).block()
+                
+                roi_within_block = clipped_block_roi - full_block_roi[0]
+                self.Output.stype.copy_data( result[roiToSlice(*output_roi)],
+                                             full_block_data[roiToSlice(*roi_within_block)] )
             else:
                 # Data doesn't exist yet in the cache.
                 # Request the full block, but then discard the parts we don't need.


### PR DESCRIPTION
Added option to bypass cache on `opLabelVolume`. This option is currently used when running conservation tracking on headless mode.

See associated PR: https://github.com/ilastik/ilastik/pull/1427