### PR TITLE
Checking for BypassModeEnabled slot when propagating dirty

### DIFF
--- a/lazyflow/operators/opLabelVolume.py
+++ b/lazyflow/operators/opLabelVolume.py
@@ -134,7 +134,9 @@ class OpLabelVolume(Operator):
         self._setBG()
 
     def propagateDirty(self, slot, subindex, roi):
-        if slot == self.Method:
+        if slot == self.BypassModeEnabled:
+            pass
+        elif slot == self.Method:
             # We are changing the labeling method. In principle, the labelings
             # are equivalent, but not necessarily the same!
             self.Output.setDirty(slice(None))
@@ -232,13 +234,16 @@ class OpLabelingABC(Operator):
         self.Output.meta.dtype = self.labelType
 
     def propagateDirty(self, slot, subindex, roi):
-        # a change in either input or background makes the whole
-        # time-channel-slice dirty (CCL is a global operation)
-        outroi = roi.copy()
-        outroi.start[1:4] = (0, 0, 0)
-        outroi.stop[1:4] = self.Input.meta.shape[1:4]
-        self.Output.setDirty(outroi)
-        self.CachedOutput.setDirty(outroi)
+        if slot == self.BypassModeEnabled:
+            pass
+        else:
+            # a change in either input or background makes the whole
+            # time-channel-slice dirty (CCL is a global operation)
+            outroi = roi.copy()
+            outroi.start[1:4] = (0, 0, 0)
+            outroi.stop[1:4] = self.Input.meta.shape[1:4]
+            self.Output.setDirty(outroi)
+            self.CachedOutput.setDirty(outroi)
 
     def setInSlot(self, slot, subindex, roi, value):
         #    "Invalid slot for setInSlot(): {}".format( slot.name )

--- a/lazyflow/operators/opSimpleBlockedArrayCache.py
+++ b/lazyflow/operators/opSimpleBlockedArrayCache.py
@@ -9,6 +9,7 @@ from lazyflow.rtype import SubRegion
 
 class OpSimpleBlockedArrayCache(OpUnblockedArrayCache):
     BlockShape = InputSlot(optional=True)
+    BypassModeEnabled = InputSlot(value=False)
 
     def __init__(self, *args, **kwargs):
         super( OpSimpleBlockedArrayCache, self ).__init__(*args, **kwargs)
@@ -90,4 +91,10 @@ class OpSimpleBlockedArrayCache(OpUnblockedArrayCache):
             req = Request( partial( copy_block, full_block_roi, clipped_block_roi ) )
             pool.add(req)
         pool.wait()
+        
+    def propagateDirty(self, slot, subindex, roi):
+        if slot == self.BypassModeEnabled:
+            pass
+        else:
+            super(OpSimpleBlockedArrayCache, self ).propagateDirty(slot, subindex, roi)
         

--- a/lazyflow/operators/opSimpleBlockedArrayCache.py
+++ b/lazyflow/operators/opSimpleBlockedArrayCache.py
@@ -9,7 +9,6 @@ from lazyflow.rtype import SubRegion
 
 class OpSimpleBlockedArrayCache(OpUnblockedArrayCache):
     BlockShape = InputSlot(optional=True)
-    BypassModeEnabled = InputSlot(value=False)
 
     def __init__(self, *args, **kwargs):
         super( OpSimpleBlockedArrayCache, self ).__init__(*args, **kwargs)

--- a/lazyflow/operators/opUnblockedArrayCache.py
+++ b/lazyflow/operators/opUnblockedArrayCache.py
@@ -52,7 +52,6 @@ class OpUnblockedArrayCache(Operator, ManagedBlockedCache):
     Input = InputSlot(allow_mask=True)
     CompressionEnabled = InputSlot(value=False) # If True, compression will be enabled for certain dtypes
     Output = OutputSlot(allow_mask=True)
-    BypassModeEnabled = InputSlot(value=False)
 
     CleanBlocks = OutputSlot() # A list of slicings indicating which blocks are stored in the cache and clean.
     
@@ -191,7 +190,7 @@ class OpUnblockedArrayCache(Operator, ManagedBlockedCache):
             self._store_block_data(block_roi, block_data)
 
     def propagateDirty(self, slot, subindex, roi):
-        if slot == self.BypassModeEnabled or slot == self.CompressionEnabled:
+        if slot == self.CompressionEnabled:
           pass 
         else:
             dirty_roi = self._standardize_roi( roi.start, roi.stop )

--- a/tests/testOpBlockedArrayCache.py
+++ b/tests/testOpBlockedArrayCache.py
@@ -431,7 +431,7 @@ class TestOpBlockedArrayCache(unittest.TestCase):
         opCache.BypassModeEnabled.setValue(True)
 
         # We can set 'fixAtCurrent', but it makes no difference.        
-        opCache.fixAtCurrent.setValue(True)
+        opCache.fixAtCurrent.setValue(False)
 
         
         expectedAccessCount = 0


### PR DESCRIPTION
Checking for `BypassModeEnabled` slot when propagating dirty and moved `BypassModeEnabled` from `opSimpleBlockedArrayCache` to `opUnblockedArrayCache`.

Also, set `fixedAtCurrent` to false in `testBypassMode` of  `testOpBlockedArrayCache`.