### PR TITLE
Fix/op input data reader

### DIFF
--- a/lazyflow/operators/ioOperators/opInputDataReader.py
+++ b/lazyflow/operators/ioOperators/opInputDataReader.py
@@ -285,22 +285,15 @@ class OpInputDataReader(Operator):
 
         if isSingleFile is True:
             opReader = OpStreamingHdf5SequenceReaderS(parent=self)
-            try:
-                externalPaths = [PathComponents(p.strip()).externalPath
-                                 for p in filePath.split(os.path.pathsep)]
-                opReader.GlobString.setValue(filePath)
-                h5file = h5py.File(externalPaths[0], 'r')
-                opReader.Hdf5File.setValue(h5file)
-                return ([opReader], opReader.OutputImage)
-            except OpStreamingHdf5SequenceReaderS.WrongFileTypeError:
-                return ([], None)
         elif isMultiFile is True:
             opReader = OpStreamingHdf5SequenceReaderM(parent=self)
-            try:
-                opReader.GlobString.setValue(filePath)
-                return ([opReader], opReader.OutputImage)
-            except OpStreamingHdf5SequenceReaderS.WrongFileTypeError:
-                return ([], None)
+
+        try:
+            opReader.GlobString.setValue(filePath)
+            return ([opReader], opReader.OutputImage)
+        except (OpStreamingHdf5SequenceReaderM.WrongFileTypeError,
+                OpStreamingHdf5SequenceReaderS.WrongFileTypeError):
+            return ([], None)
         else:
             return ([], None)
 

--- a/lazyflow/operators/ioOperators/opStreamingHdf5SequenceReaderM.py
+++ b/lazyflow/operators/ioOperators/opStreamingHdf5SequenceReaderM.py
@@ -93,7 +93,7 @@ class OpStreamingHdf5SequenceReaderM(Operator):
 
     def __init__(self, *args, **kwargs):
         super(OpStreamingHdf5SequenceReaderM, self).__init__(*args, **kwargs)
-        self._hdf5Files = None
+        self._hdf5Files = []
         self._readers = []
         self._opStacker = OpMultiArrayStacker(parent=self)
         self._opStacker.AxisIndex.setValue(0)


### PR DESCRIPTION
Recent changes to the interface of `OpStreamingHdf5SequenceReaderS` (handles hdf5 file itself now) have not been properly propagated to `OpInputDataReader`. Thus the test was failing. This is fixed now.