### PR TITLE
added flake8 style checking

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,29 @@
+[flake8]
+select=
+    # pyflakes Messages:
+    # module imported but unused
+    F401,
+    # import module from line N shadowed by loop variable    
+    F402,
+    # ‘from module import *’ used; unable to detect undefined names    
+    F403,
+    # future import(s) name after other statements    
+    F404,
+    # name may be undefined, or defined from star imports: module    
+    F405,
+    # ‘from module import *’ only allowed at module level    
+    F406,
+    # an undefined __future__ feature name was imported    
+    F407,
+    # assertion test is a tuple, which are always True
+    F631,
+    # an except: block as not the last exception handler
+    F707,
+    # local variable name is assigned to but never used
+    F841,
+    # pychecker messages
+    # Deprecation warnings
+    W6
+
+
+exclude=__init__.py

--- a/.flake8
+++ b/.flake8
@@ -3,17 +3,17 @@ select=
     # pyflakes Messages:
     # module imported but unused
     F401,
-    # import module from line N shadowed by loop variable    
+    # import module from line N shadowed by loop variable
     F402,
-    # ‘from module import *’ used; unable to detect undefined names    
+    # ‘from module import *’ used; unable to detect undefined names
     F403,
-    # future import(s) name after other statements    
+    # future import(s) name after other statements
     F404,
-    # name may be undefined, or defined from star imports: module    
+    # name may be undefined, or defined from star imports: module
     F405,
-    # ‘from module import *’ only allowed at module level    
+    # ‘from module import *’ only allowed at module level
     F406,
-    # an undefined __future__ feature name was imported    
+    # an undefined __future__ feature name was imported
     F407,
     # assertion test is a tuple, which are always True
     F631,

--- a/circle.yml
+++ b/circle.yml
@@ -25,9 +25,9 @@ dependencies:
 
     - >
       if [ ! -d ${TEST_ENV_PREFIX} ]; then
-          conda create -y -n ${TEST_ENV_NAME} -c ilastik ilastik-deps-pc-headless ilastik-meta nose;
+          conda create -y -n ${TEST_ENV_NAME} -c ilastik ilastik-deps-pc-headless ilastik-meta nose flake8;
       else
-          conda install -y -n ${TEST_ENV_NAME} -c ilastik ilastik-deps-pc-headless nose;
+          conda install -y -n ${TEST_ENV_NAME} -c ilastik ilastik-deps-pc-headless nose flake8;
       fi
 
     # Replace packaged source with full git repo
@@ -45,3 +45,12 @@ dependencies:
 test:
   override:
     - cd ${TEST_ENV_PREFIX}/ilastik-meta/lazyflow/tests && ${TEST_ENV_PREFIX}/bin/nosetests --nologcapture --ignore-files=testInterpolatedFeatures.py .
+    - mkdir -p $CIRCLE_TEST_REPORTS/lazyflow-flake8
+    - >
+      cd ${TEST_ENV_PREFIX}/ilastik-meta/lazyflow/ &&
+      ${TEST_ENV_PREFIX}/bin/flake8
+      --statistics
+      --config=.flake8
+      --exit-zero
+      --output=$CIRCLE_TEST_REPORTS/lazyflow-flake8/flake8.out.txt
+      lazyflow


### PR DESCRIPTION
Added style checking using flake8.

Added only checks against issues that are basically no-brainers to fix and should be eliminated:

 * imports: unused, shadowed, issues related to * imports, misplaced __future__ imports
 * unused variables
 * deprecated syntax (according to pep8)

CircleCI is, unfortunately, not really capable of interpreting the results. Results could be converted to junit xml, but that would also clutter the test results. So, to see the result one has to browse to the build artefacts manually.

This PR is created independently from PR  #235, but in a similar spirit.