### PR TITLE
better lshdf5 and globbing for single file h5 stacks

### DIFF
--- a/lazyflow/operators/ioOperators/opStreamingHdf5SequenceReaderS.py
+++ b/lazyflow/operators/ioOperators/opStreamingHdf5SequenceReaderS.py
@@ -170,13 +170,22 @@ class OpStreamingHdf5SequenceReaderS(Operator):
         """Matches a list of globStrings to internal paths of files
 
         Args:
-            hdf5File: h5py.File object
+            hdf5File: h5py.File object, or path(string). If a string is given,
+              the file is opened and closed in this method.
             globStrings: string. glob or path strings delimited by os.pathsep
 
         Returns:
             List of internal paths matching the globstrings that were found in
             the provided h5py.File object
         """
+        if not isinstance(hdf5File, h5py.File):
+            f = h5py.File(hdf5File, mode='r')
+            try:
+                ret = OpStreamingHdf5SequenceReaderS.expandGlobStrings(f, globStrings)
+            finally:
+                f.close()
+            return ret
+
         ret = []
         # Parse list into separate globstrings and combine them
         for globString in globStrings.split(os.path.pathsep):

--- a/lazyflow/operators/ioOperators/opStreamingHdf5SequenceReaderS.py
+++ b/lazyflow/operators/ioOperators/opStreamingHdf5SequenceReaderS.py
@@ -179,11 +179,8 @@ class OpStreamingHdf5SequenceReaderS(Operator):
             the provided h5py.File object
         """
         if not isinstance(hdf5File, h5py.File):
-            f = h5py.File(hdf5File, mode='r')
-            try:
+            with h5py.File(hdf5File, mode='r') as f:
                 ret = OpStreamingHdf5SequenceReaderS.expandGlobStrings(f, globStrings)
-            finally:
-                f.close()
             return ret
 
         ret = []

--- a/lazyflow/utility/__init__.py
+++ b/lazyflow/utility/__init__.py
@@ -29,7 +29,8 @@ from orderedSignal import OrderedSignal
 from fileLock import FileLock
 from tracer import Tracer, traceLogged
 from pathHelpers import (
-    PathComponents, getPathVariants, isUrl, make_absolute, mkdir_p, lsHdf5)
+    PathComponents, getPathVariants, isUrl, make_absolute, mkdir_p, globHdf5,
+    globList, lsHdf5)
 from roiRequestBatch import RoiRequestBatch
 from bigRequestStreamer import BigRequestStreamer
 import io_util

--- a/lazyflow/utility/pathHelpers.py
+++ b/lazyflow/utility/pathHelpers.py
@@ -365,8 +365,11 @@ def globHdf5(hdf5FileObject, globString):
         matches occurred.
     """
     pathlist = [x['name'] for x in lsHdf5(hdf5FileObject)]
-
-    matches = [x for x in pathlist
-               if fnmatch.fnmatch(x, globString)]
-
+    matches = globList(pathlist, globString)
     return sorted(matches)
+
+
+def globList(listOfPaths, globString):
+    matches = [x for x in listOfPaths
+               if fnmatch.fnmatch(x, globString)]
+    return matches

--- a/lazyflow/utility/pathHelpers.py
+++ b/lazyflow/utility/pathHelpers.py
@@ -321,7 +321,7 @@ def mkdir_p(path):
             raise
 
 
-def lsHdf5(hdf5FileObject, minShape=2):
+def lsHdf5(hdf5FileObject, minShape=2, maxShape=5):
     """Generates dataset list of given h5py file object
 
     Args:
@@ -335,7 +335,7 @@ def lsHdf5(hdf5FileObject, minShape=2):
 
     def addObjectNames(objectName, obj):
         if isinstance(obj, h5py.Dataset):
-            if len(obj.shape) >= minShape:
+            if (len(obj.shape) >= minShape) and (len(obj.shape) <= maxShape):
                 listOfDatasets.append({
                     'name': objectName,
                     'object': obj

--- a/tests/testOpStreamingHdf5SequenceReaderS.py
+++ b/tests/testOpStreamingHdf5SequenceReaderS.py
@@ -158,6 +158,33 @@ class TestOpStreamingHdf5SequenceReader(unittest.TestCase):
 
         self.assertTrue(True)
 
+    def test_expandGlobStrings(self):
+        expected_datasets = ['g1/g2/data2', 'g1/g2/data3']
+
+        with tempdir() as d:
+            file_name = '{}/test.h5'.format(d)
+            try:
+                f = h5py.File(file_name, mode='w')
+                g1 = f.create_group('g1')
+                g2 = g1.create_group('g2')
+                g3 = f.create_group('g3')
+                g1.create_dataset('data1', data=numpy.ones((10, 10)))
+                g2.create_dataset('data2', data=numpy.ones((10, 10)))
+                g2.create_dataset('data3', data=numpy.ones((10, 10)))
+                g3.create_dataset('data4', data=numpy.ones((10, 10)))
+                f.flush()
+
+                glob_res1 = OpStreamingHdf5SequenceReaderS.expandGlobStrings(
+                    f, '{}/g1/g2/data*'.format(file_name))
+                self.assertEqual(glob_res1, expected_datasets)
+
+            finally:
+                f.close()
+
+            glob_res2 = OpStreamingHdf5SequenceReaderS.expandGlobStrings(
+                file_name, '{}/g1/g2/data*'.format(file_name))
+            self.assertEqual(glob_res2, expected_datasets)
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
These changes facilitate enabling loading single file h5 stacks from the ilastik GUI.

Also noticed that `OpStreamingHdf5SequenceReaderS.expandGlobstring` wasn't tested and added a test to make sure the changes introduced with this PR wouldn't break anything.