### PR TITLE
added explicit checking for 'None' as internal path

### DIFF
--- a/lazyflow/operators/ioOperators/opStreamingHdf5SequenceReaderS.py
+++ b/lazyflow/operators/ioOperators/opStreamingHdf5SequenceReaderS.py
@@ -229,6 +229,8 @@ class OpStreamingHdf5SequenceReaderS(Operator):
             raise OpStreamingHdf5SequenceReaderS.WrongFileTypeError(globString)
 
         if len(pathComponents) == 1:
+            if pathComponents[0].internalPath is None:
+                raise OpStreamingHdf5SequenceReaderS.NoInternalPlaceholderError(globString)
             if '*' not in pathComponents[0].internalPath:
                 raise OpStreamingHdf5SequenceReaderS.NoInternalPlaceholderError(globString)
             if '*' in pathComponents[0].externalPath:


### PR DESCRIPTION
Fixes an error that was introduced with the latest master commit, allowing 'None' as an internal path for H5 files