### PR TITLE
insert missing cleanUp call

### DIFF
--- a/tests/testOpBigTiffReader.py
+++ b/tests/testOpBigTiffReader.py
@@ -74,6 +74,8 @@ class TestOpBigTiffReader(unittest.TestCase):
 
         self.assertEqual(op.Output.meta.shape, self.data.shape)
         output_data = op.Output[:].wait()
+
+        # clean up closes tiff file, which prevents PermissionError on Windows
         op.cleanUp()
 
         numpy.testing.assert_array_equal(output_data, self.data)

--- a/tests/testOpBigTiffReader.py
+++ b/tests/testOpBigTiffReader.py
@@ -74,6 +74,7 @@ class TestOpBigTiffReader(unittest.TestCase):
 
         self.assertEqual(op.Output.meta.shape, self.data.shape)
         output_data = op.Output[:].wait()
+        op.cleanUp()
 
         numpy.testing.assert_array_equal(output_data, self.data)
 


### PR DESCRIPTION
testOpBigTiffReader failed due to PermissionError (used by another process) in teardownClass of TestOpBigTiffReader