### PR TITLE
enable faulthandler on all platforms.

### DIFF
--- a/lazyflow/__init__.py
+++ b/lazyflow/__init__.py
@@ -20,13 +20,8 @@ from __future__ import absolute_import
 # This information is also available on the ilastik web site at:
 #		   http://ilastik.org/license/
 ###############################################################################
-import sys
-if not sys.platform.startswith('win'): # todo: fix
-    try:
-        import faulthandler
-        faulthandler.enable()
-    except ImportError:
-        pass
+import faulthandler
+faulthandler.enable()  # noqa
 
 from . import utility
 from . import request


### PR DESCRIPTION
Also faulthandler is part of the standard library since python 3.3 => do not 'except ImportError'.
Fixes #262 