### PR TITLE
Refactor partner and partners

### DIFF
--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -356,8 +356,8 @@ class Operator(metaclass=OperatorMetaClass):
     #  FIXME: Unused function?
     def disconnectFromDownStreamPartners(self):
         for slot in list(self.inputs.values()) + list(self.outputs.values()):
-            partners = list(slot.partners)
-            for p in partners:
+            downstream_slots = list(slot.downstream_slots)
+            for p in downstream_slots:
                 p.disconnect()
 
     def _initCleanup(self):
@@ -376,14 +376,14 @@ class Operator(metaclass=OperatorMetaClass):
 
         for s in list(self.inputs.values()) + list(self.outputs.values()):
             # See note about the externally_managed flag in Operator.__init__
-            partners = list(p for p in s.partners
+            downstream_slots = list(p for p in s.downstream_slots
                             if p.getRealOperator() is not None and
                             not p.getRealOperator().externally_managed)
-            if len(partners) > 0:
+            if len(downstream_slots) > 0:
                 msg = ("Cannot clean up this operator ({}): Slot '{}'"
                        " is still providing data to downstream"
                        " operators!\n".format( self.name, s.name))
-                for i, p in enumerate(s.partners):
+                for i, p in enumerate(s.downstream_slots):
                     msg += "Downstream Partner {}: {}.{}".format(
                         i, p.getRealOperator().name, p.name)
                 raise RuntimeError(msg)

--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -286,7 +286,7 @@ class Operator(metaclass=OperatorMetaClass):
         for i in sorted(self.inputSlots, key=lambda s: s._global_slot_id):
             if i.name not in self.inputs:
                 ii = i._getInstance(self)
-                ii.connect(i.partner)
+                ii.connect(i.upstream_slot)
                 self.inputs[i.name] = ii
 
         for k, v in list(self.inputs.items()):
@@ -330,7 +330,7 @@ class Operator(metaclass=OperatorMetaClass):
 
     def _setDefaultInputValues(self):
         for i in list(self.inputs.values()):
-            if (i.partner is None and
+            if (i.upstream_slot is None and
                 i._value is None and
                 i._defaultValue is not None):
                 i.setValue(i._defaultValue)
@@ -461,7 +461,7 @@ class Operator(metaclass=OperatorMetaClass):
         try:
             # Determine new "ready" flags
             for k, oslot in list(self.outputs.items()):
-                if oslot.partner is None:
+                if oslot.upstream_slot is None:
                     # Special case, operators can flag an output as not actually being ready yet,
                     #  in which case we do NOT notify downstream connections.
                     if oslot.meta.NOTREADY:
@@ -484,7 +484,7 @@ class Operator(metaclass=OperatorMetaClass):
             # Something went wrong
             # Make the operator-supplied outputs unready again
             for k, oslot in list(self.outputs.items()):
-                if oslot.partner is None:
+                if oslot.upstream_slot is None:
                     oslot.disconnect() # Forces unready state
             raise
 
@@ -498,9 +498,9 @@ class Operator(metaclass=OperatorMetaClass):
         def set_output_unready(s):
             for ss in s._subSlots:
                 set_output_unready(ss)
-            if s.partner is None and s._value is None:
+            if s.upstream_slot is None and s._value is None:
                 was_ready = s.meta._ready
-                s.meta._ready &= (s.partner is not None)
+                s.meta._ready &= (s.upstream_slot is not None)
                 if was_ready and not s.meta._ready:
                     newly_unready_slots.append(s)
 
@@ -531,8 +531,8 @@ class Operator(metaclass=OperatorMetaClass):
             #  you probably need to override this method.
             # If your subclass provides an implementation of this method, there 
             #  is no need for it to call super().setupOutputs()
-            assert slot.partner is not None, \
-                "Output slot '{}' of operator '{}' has no upstream partner, " \
+            assert slot.upstream_slot is not None, \
+                "Output slot '{}' of operator '{}' has no upstream_slot, " \
                 "so you must override setupOutputs()".format( slot.name, self.name )
 
     def execute(self, slot, subindex, roi, result):

--- a/lazyflow/operatorWrapper.py
+++ b/lazyflow/operatorWrapper.py
@@ -223,7 +223,7 @@ class OperatorWrapper(Operator):
             self._name = "Wrapped " + op.name
 
         # If anyone calls setValue() on one of these slots,
-        # forward the setValue call to the slot's partner (the
+        # forward the setValue call to the slot's upstream_slot (the
         # outer slot on the operator wrapper)
         for slot in list(op.inputs.values()):
             slot.backpropagate_values = True
@@ -238,16 +238,16 @@ class OperatorWrapper(Operator):
             # wrapping
             if outerSlot.name in self.promotedSlotNames:
                 outerSlot.insertSlot(index, length)
-                partner = outerSlot[index]
+                upstream_slot = outerSlot[index]
             else:
-                partner = outerSlot
-            if op.inputs[key].partner is not None:
+                upstream_slot = outerSlot
+            if op.inputs[key].upstream_slot is not None:
                 msg = ("Can't set up OperatorWrapper connections."
                        " Input slot {} is already connected to a"
-                       " partner (must have happened in {}'s"
+                       " upstream_slot (must have happened in {}'s"
                        " constructor".format(key, op.name))
                 raise RuntimeError(msg)
-            op.inputs[key].connect(partner)
+            op.inputs[key].connect(upstream_slot)
 
         # Connect our outer output slots to the inner operator's output slots.
         for key, mslot in list(self.outputs.items()):

--- a/lazyflow/operatorWrapper.py
+++ b/lazyflow/operatorWrapper.py
@@ -292,5 +292,5 @@ class OperatorWrapper(Operator):
 
     def setInSlot(self, slot, subindex, key, value):
         # Nothing to do here. Calls to Slot.setitem are already
-        # forwarded to all slot partners.
+        # forwarded to all downstream partners.
         pass

--- a/lazyflow/operators/generic.py
+++ b/lazyflow/operators/generic.py
@@ -201,7 +201,7 @@ class OpMultiArrayStacker(Operator):
 
         for inSlot in self.inputs["Images"]:
             inTagKeys = [ax.key for ax in inSlot.meta.axistags]
-            if inSlot.partner is not None:
+            if inSlot.upstream_slot is not None:
                 self.Output.meta.assignFrom( inSlot.meta )
 
                 outTagKeys = [ax.key for ax in self.outputs["Output"].meta.axistags]
@@ -340,7 +340,6 @@ class OpSingleChannelSelector(Operator):
     Output = OutputSlot()
 
     def setupOutputs(self):
-        
         channelAxis=self.Input.meta.axistags.channelIndex
         inshape=list(self.Input.meta.shape)
         outshape = list(inshape)
@@ -365,14 +364,14 @@ class OpSingleChannelSelector(Operator):
 
         # Output can't be accessed unless the input has enough channels
         # We can't assert here because it's okay to configure this slot incorrectly as long as it is never accessed.
-        # Because the order of callbacks isn't well defined, people may not disconnect this operator from its 
-        #  upstream partner until after it has already been configured.
+        # Because the order of callbacks isn't well defined, people may not disconnect this operator from its
+        #  upstream_slot until after it has already been configured.
         # Again, that's okay as long as it isn't accessed.
         #assert self.Input.meta.getTaggedShape()['c'] > self.Index.value, \
         #        "Requested channel {} is out of range of input data (shape {})".format(self.Index.value, self.Input.meta.shape)
         if self.Input.meta.getTaggedShape()['c'] <= self.Index.value:
             self.Output.meta.NOTREADY = True
-        
+
     def execute(self, slot, subindex, roi, result):
         index=self.inputs["Index"].value
         channelIndex = self.Input.meta.axistags.channelIndex

--- a/lazyflow/operators/oldVigraOperators.py
+++ b/lazyflow/operators/oldVigraOperators.py
@@ -831,7 +831,7 @@ class OpBaseFilter(Operator):
             channelIndex = len(inputSlot.meta.shape)
 
         self.outputs["Output"].meta.dtype = self.outputDtype
-        p = self.inputs["Input"].partner
+        p = self.inputs["Input"].upstream_slot
         at = copy.copy(inputSlot.meta.axistags)
 
         if at.axisTypeCount(vigra.AxisType.Channels) == 0:

--- a/lazyflow/operators/valueProviders.py
+++ b/lazyflow/operators/valueProviders.py
@@ -403,7 +403,7 @@ class OpPrecomputedInput(Operator):
                 # If the slow input became dirty, the party is over.
                 # We can't use the pre-computed input anymore.
                 with self._lock:
-                    if self.Output.partner != self.SlowInput:
+                    if self.Output.upstream_slot != self.SlowInput:
                         self.Output.connect(self.SlowInput)
                         self.Output.setDirty(roi)
         elif slot is self.Reset:

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -529,7 +529,10 @@ class Slot(object):
                 if upstream_slot.level == self.level:
                     assert isinstance(upstream_slot.stype, type(self.stype)), \
                         "Can't connect slots of non-matching stypes!" \
-                        " Attempting to connect '{}' (stype: {}) to '{}' (stype: {})".format(self.name, self.stype, upstream_slot.name, upstream_slot.stype)
+                        f"Tried to connect {self.getRealOperator()} with {upstream_slot.getRealOperator()}." \
+                        " Attempting to connect '{}' (stype: {}) to '{}' (stype: {})".format(
+                            self.name, self.stype, upstream_slot.name, upstream_slot.stype)
+
                     self.upstream_slot = upstream_slot
                     notifyReady = (self.upstream_slot.meta._ready and
                                    not self.meta._ready)

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -497,9 +497,9 @@ class Slot(object):
                 self.disconnect()
                 return
 
-            assert isinstance(upstream_slot, Slot), ("Slot.connect() can only be used to"
-                                               " connect other Slots.  Did you mean"
-                                               " to use Slot.setValue()?")
+            assert isinstance(upstream_slot, Slot), (
+                "Slot.connect() can only be used to connect other Slots. Did "
+                "you mean to use Slot.setValue()?")
             assert self.allow_mask or (not upstream_slot.meta.has_mask), \
                         "The operator, \"%s\", is being setup to receive a masked array as input to slot, \"%s\"," \
                         " from the output slot, \"%s\", on operator, \"%s\". This is currently not supported." \

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -527,7 +527,7 @@ class Slot(object):
                 upstream_slot._sig_unready.subscribe( self._handleUpstreamUnready )
                 self._value = None
                 if upstream_slot.level == self.level:
-                    assert isinstance(upstream_slot.stype, type(self.stype)), \
+                    assert upstream_slot.stype.isCompatible(type(self.stype)), \
                         "Can't connect slots of non-matching stypes!" \
                         f"Tried to connect {self.getRealOperator()} with {upstream_slot.getRealOperator()}." \
                         " Attempting to connect '{}' (stype: {}) to '{}' (stype: {})".format(

--- a/lazyflow/tools/schematic.py
+++ b/lazyflow/tools/schematic.py
@@ -96,13 +96,13 @@ class SvgSlot(DrawableABC, ConnectableABC):
     def key(self):
         return hex(id(self._slot))
 
-    def partnerKey(self):
+    def upstream_slot_key(self):
         return hex(id(self._slot.upstream_slot))
 
     def drawConnectionToPartner(self, canvas):
         if self._slot.upstream_slot in slot_registry:
             myIdStr = '#' + self.key()
-            partnerIdStr = '#' + self.partnerKey()
+            partnerIdStr = '#' + self.upstream_slot_key()
             pathName = "pathTo" + self.key()
             canvas += svg.connector_path( id_=pathName, inkscape__connection_start=partnerIdStr, inkscape__connection_end=myIdStr )
 
@@ -124,7 +124,7 @@ class SvgMultiSlot(DrawableABC, ConnectableABC):
     def key(self):
         return hex(id(self.mslot))
 
-    def partnerKey(self):
+    def upstream_slot_key(self):
         return hex(id(self.mslot.upstream_slot))
 
     def __getitem__(self, i):
@@ -144,7 +144,7 @@ class SvgMultiSlot(DrawableABC, ConnectableABC):
     def drawConnectionToPartner(self, canvas):
         if self.mslot.upstream_slot in slot_registry:
             myIdStr = '#' + self.key()
-            partnerIdStr = '#' + self.partnerKey()
+            partnerIdStr = '#' + self.upstream_slot_key()
             pathName = "pathTo" + self.key()
             canvas += svg.connector_path( id_=pathName, inkscape__connection_start=partnerIdStr, inkscape__connection_end=myIdStr )
         else:

--- a/lazyflow/tools/schematic.py
+++ b/lazyflow/tools/schematic.py
@@ -95,12 +95,12 @@ class SvgSlot(DrawableABC, ConnectableABC):
     
     def key(self):
         return hex(id(self._slot))
-    
+
     def partnerKey(self):
-        return hex(id(self._slot.partner))
+        return hex(id(self._slot.upstream_slot))
 
     def drawConnectionToPartner(self, canvas):
-        if self._slot.partner in slot_registry:
+        if self._slot.upstream_slot in slot_registry:
             myIdStr = '#' + self.key()
             partnerIdStr = '#' + self.partnerKey()
             pathName = "pathTo" + self.key()
@@ -125,7 +125,7 @@ class SvgMultiSlot(DrawableABC, ConnectableABC):
         return hex(id(self.mslot))
 
     def partnerKey(self):
-        return hex(id(self.mslot.partner))
+        return hex(id(self.mslot.upstream_slot))
 
     def __getitem__(self, i):
         return self.subslots[i]
@@ -142,7 +142,7 @@ class SvgMultiSlot(DrawableABC, ConnectableABC):
             canvas += self._code
 
     def drawConnectionToPartner(self, canvas):
-        if self.mslot.partner in slot_registry:
+        if self.mslot.upstream_slot in slot_registry:
             myIdStr = '#' + self.key()
             partnerIdStr = '#' + self.partnerKey()
             pathName = "pathTo" + self.key()
@@ -389,15 +389,15 @@ def get_column_within_parent( op ):
     
     max_column = 0
     for slot in list(op.inputs.values()):
-        if slot.partner is None:
+        if slot.upstream_slot is None:
             continue
-        upstream_op = slot.partner.getRealOperator()
+        upstream_op = slot.upstream_slot.getRealOperator()
         if upstream_op is not op.parent and upstream_op is not op:
             assert upstream_op.parent is op.parent, \
-                "Slot '{}' of operator '{}' and it's upstream partner" \
+                "Slot '{}' of operator '{}' and it's upstream_slot" \
                 " (slot '{}' of operator '{}') do not have the same parent operator.\n" \
                 "parent is '{}', upstream parent is '{}'".format(
-                 slot.name, op.name, slot.partner.name, upstream_op.name, op.parent.name, upstream_op.parent.name)
+                 slot.name, op.name, slot.upstream_slot.name, upstream_op.name, op.parent.name, upstream_op.parent.name)
             max_column = max( max_column, get_column_within_parent(upstream_op)+1 )
 
     memoized_columns[op] = max_column

--- a/lazyflow/tools/schematic_abc.py
+++ b/lazyflow/tools/schematic_abc.py
@@ -53,11 +53,11 @@ class ConnectableABC(with_metaclass(ABCMeta, object)):
         return NotImplemented
     
     @abstractmethod
-    def partnerKey(self):
+    def upstream_slot_key(self):
         return NotImplemented
 
     @classmethod
     def __subclasshook__(cls, C):
         if cls is DrawableABC:
-            return True if _has_attributes(C, ['key', 'partnerKey']) else False
+            return True if _has_attributes(C, ['key', 'upstream_slot_key']) else False
         return NotImplemented

--- a/tests/testMultislotResize.py
+++ b/tests/testMultislotResize.py
@@ -79,8 +79,8 @@ class TestMultiSlotResize(object):
         opB.Inputs.connect( opA.Inputs )
         opA.Inputs.resize(2)
         assert len(opB.Inputs) == 2
-        assert opB.Inputs[0].partner == opA.Inputs[0]
-        assert opB.Inputs[1].partner == opA.Inputs[1]
+        assert opB.Inputs[0].upstream_slot == opA.Inputs[0]
+        assert opB.Inputs[1].upstream_slot == opA.Inputs[1]
                 
 
 if __name__ == "__main__":


### PR DESCRIPTION
that was a rather old branch of mine, so I'm not quite sure if this is complete, or whether it still works as it is supposed to after rebasing it to master. Will check this out in the coming weeks. I've added this PR already, so that I do not forget it again.

Basically makes `lazyflow.operator.Operator`, `lazyflow.slot.Slot` and related classes more readable by renaming

* `partners` to `downstream_slots`
* `partner` to `upstream_slot`