### PR TITLE
Cleaned-up OpArrayPiper

### DIFF
--- a/lazyflow/operators/opArrayPiper.py
+++ b/lazyflow/operators/opArrayPiper.py
@@ -53,8 +53,9 @@ class OpArrayPiper(Operator):
             self.outputs["Output"].setDirty(slice(None))
 
     def setInSlot(self, slot, subindex, roi, value):
-        # Forward to output
+        # Implementations of this method is only needed to satisfy the flow of
+        # the __setitem__ method for input slots. Nothing needs to be done here
+        # as the input of the value slot is manipulated directly. When the
+        # output is requested, execute is called.
         assert subindex == ()
         assert slot == self.Input
-        key = roi.toSlice()
-        self.outputs["Output"][key] = value


### PR DESCRIPTION
This is a micro PR with only a single commit.

I removed a tiny bit of the implementation of `OpArrayPiper.setInSlot`. The Code there did not really make any sense (also the `slot.__setItem__` would not do anything for the output slot). However, I think the code was very misleading in such a tiny operator as this one. So unless I have overseen some magic here that I didn't see...