### PR TITLE
Do not format output filename on bad format string

### DIFF
--- a/lazyflow/operators/ioOperators/opExportSlot.py
+++ b/lazyflow/operators/ioOperators/opExportSlot.py
@@ -145,7 +145,7 @@ class OpExportSlot(Operator):
         for key, (start, stop) in zip( self.Input.meta.getAxisKeys(), roi.transpose() ):
             optional_replacements[key + '_start'] = start
             optional_replacements[key + '_stop'] = stop
-        formatted_path = format_known_keys( path_format, optional_replacements )
+        formatted_path = format_known_keys( path_format, optional_replacements, strict=False )
         result[0] = formatted_path
         return result
 

--- a/lazyflow/operators/ioOperators/opFormattedDataExport.py
+++ b/lazyflow/operators/ioOperators/opFormattedDataExport.py
@@ -233,7 +233,7 @@ class OpFormattedDataExport(Operator):
         
         # use partial formatting to fill in non-coordinate name fields
         name_format = self.OutputFilenameFormat.value
-        partially_formatted_path = format_known_keys( name_format, known_keys )
+        partially_formatted_path = format_known_keys( name_format, known_keys, strict=False )
         self._opExportSlot.OutputFilenameFormat.setValue( partially_formatted_path )
 
         internal_dataset_format = self.OutputInternalPath.value 

--- a/lazyflow/utility/format_known_keys.py
+++ b/lazyflow/utility/format_known_keys.py
@@ -65,6 +65,14 @@ def format_known_keys(s, entries, strict=True):
     
     >>> format_known_keys("Hello, {first_name:}, my name is {my_name}!", {"first_name" : [1,2,2]})
     'Hello, [1, 2, 2], my name is {my_name}!'
+
+    >>> format_known_keys("Hello, {first_name}, my name is {my_name", {'first_name' : 'Jim'})  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+      ...
+    ValueError: ...
+
+    >>> format_known_keys("Hello, {first_name}, my name is {my_name", {'first_name' : 'Jim'}, strict=False)
+    'Hello, {first_name}, my name is {my_name'
     """
     if strict:
         return format_known_keys_strict(s, entries)

--- a/lazyflow/utility/format_known_keys.py
+++ b/lazyflow/utility/format_known_keys.py
@@ -74,11 +74,11 @@ def format_known_keys(s, entries, strict=True):
     >>> format_known_keys("Hello, {first_name}, my name is {my_name", {'first_name' : 'Jim'}, strict=False)
     'Hello, {first_name}, my name is {my_name'
     """
-    if strict:
-        return format_known_keys_strict(s, entries)
     try:
-        format_known_keys_strict(s, entries)
+        return format_known_keys_strict(s, entries)
     except ValueError:
+        if strict:
+            raise
         return s
 
 

--- a/lazyflow/utility/format_known_keys.py
+++ b/lazyflow/utility/format_known_keys.py
@@ -21,13 +21,43 @@
 ###############################################################################
 import string
 
-def format_known_keys(s, entries):
+
+def format_known_keys_strict(s, entries):
+    """Strict version of format_known_keys()."""
+    formatter = string.Formatter()
+    pieces = []
+
+    for text, name, fmt, _conv in formatter.parse(s):
+        pieces.append(text)
+
+        if name in entries:
+            value = formatter.format_field(entries[name], fmt)
+            pieces.append(value)
+            continue
+
+        # Replicate the original stub
+        name = name or ''
+        fmt = fmt or ''
+        start, end, fmtsep = '', '', ''
+        if name or fmt:
+            start, end = '{', '}'
+        if fmt:
+            fmtsep = ':'
+        pieces.append(start + name + fmtsep + fmt + end)
+
+    return ''.join(pieces)
+
+
+def format_known_keys(s, entries, strict=True):
     """
     Like str.format(), but 
      (1) accepts only a dict and 
      (2) allows the dict to be incomplete, 
          in which case those entries are left alone.
     
+    Setting strict to False returns the original format string
+    if that string is malformed.
+
     Examples:
     
     >>> format_known_keys("Hello, {first_name}, my name is {my_name}", {'first_name' : 'Jim', 'my_name' : "Jon"})
@@ -36,25 +66,13 @@ def format_known_keys(s, entries):
     >>> format_known_keys("Hello, {first_name:}, my name is {my_name}!", {"first_name" : [1,2,2]})
     'Hello, [1, 2, 2], my name is {my_name}!'
     """
-    fmt = string.Formatter()
-    it = fmt.parse(s)
-    s = ''
-    for i in it:
-        if i[1] in entries:
-            val = entries[ i[1] ]
-            s += i[0] + fmt.format_field( val, i[2] )
-        else:
-            # Replicate the original stub
-            s += i[0]
-            if i[1] or i[2]:
-                s += '{'
-            if i[1]:
-                s += i[1]
-            if i[2]:
-                s += ':' + i[2]
-            if i[1] or i[2]:
-                s += '}'
-    return s
+    if strict:
+        return format_known_keys_strict(s, entries)
+    try:
+        format_known_keys_strict(s, entries)
+    except ValueError:
+        return s
+
 
 if __name__ == "__main__":
     import doctest


### PR DESCRIPTION
`format_known_keys()` raises `ValueError` if the format string is malformed:
`{spam} {eggs` is malformed because the second field is not closed.
This can happen if a format string is coming from the user:
see https://github.com/ilastik/ilastik/issues/1761.

This commit allows non-strict behaviour of `format_known_keys()`, which is
disabled by default, and enables it in places that cause the issue above.