### PR TITLE
added function to safely retrieve originalShape

### DIFF
--- a/lazyflow/metaDict.py
+++ b/lazyflow/metaDict.py
@@ -154,10 +154,29 @@ class MetaDict(defaultdict):
         return [tag.key for tag in self.axistags]
 
     def getOriginalAxisKeys(self):
+        """Returns the original axis keys
+
+        In case we have `OpReorderAxes` in the chain somewhere, the original
+        axistags are preserved in `original_axistags`, thus this is returned if
+        present. Fallback is the `axistags` attribute (via `getAxisKeys()`).
+        """
         if self.original_axistags is None:
             return self.getAxisKeys()
 
         return [tag.key for tag in self.original_axistags]
+
+    def getOriginalShape(self):
+        """Returns the original shape
+
+        In case we have `OpReorderAxes` in the chain somewhere, the original shape
+        is preserved in `original_shape`, thus this is returned if present.
+        Fallback is the `shape` attribute.
+        """
+        if self.original_shape is None:
+            assert self.shape is not None
+            return self.shape
+
+        return self.original_shape
 
     def getDtypeBytes(self):
         """


### PR DESCRIPTION
Voluminas `slotMetaInfoDisplayWidget` would previously fail if `original_shape` was not present in the meta dict. This is only the case if an `OpReorderAxes` was somewhere added in the chain.
I added a function similar to `getOriginalAxisKeys()` for the shape: `getOriginalShape()`.
Also added some comment to make it more obvious where those `original_` metadata
come from.