### PR TITLE
Enabling pixel classification mask

### DIFF
--- a/lazyflow/operators/classifierOperators.py
+++ b/lazyflow/operators/classifierOperators.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 #		   http://ilastik.org/license/
 ###############################################################################
 #Python
-from abc import abstractmethod
+from abc import abstractmethod, ABC
 import copy
 import logging
 traceLogger = logging.getLogger("TRACE." + __name__)
@@ -390,7 +390,7 @@ class OpClassifierPredict(Operator):
         if slot == self.Classifier:
             self.PMaps.setDirty()
 
-class OpBaseClassifierPredict(Operator):
+class OpBaseClassifierPredict(Operator, ABC):
     Image = InputSlot()
     LabelsCount = InputSlot()
     Classifier = InputSlot()
@@ -482,7 +482,7 @@ class OpPixelwiseClassifierPredict(OpBaseClassifierPredict):
     def _calculate_probabilities(self, roi):
         classifier = self.Classifier.value
 
-        assert issubclass(type(classifier), LazyflowPixelwiseClassifierABC), \
+        assert isinstance(classifier, LazyflowPixelwiseClassifierABC), \
             f"Classifier {classifier} must be sublcass of {LazyflowPixelwiseClassifierABC}"
 
         upstream_roi = (roi.start, roi.stop)
@@ -539,7 +539,7 @@ class OpVectorwiseClassifierPredict(OpBaseClassifierPredict):
     def _calculate_probabilities(self, roi):
         classifier = self.Classifier.value
 
-        assert issubclass(type(classifier), LazyflowVectorwiseClassifierABC), \
+        assert isinstance(classifier, LazyflowVectorwiseClassifierABC), \
             f"Classifier {classifier} must be sublcass of {LazyflowVectorwiseClassifierABC}"
 
         key = roi.toSlice()

--- a/lazyflow/operators/classifierOperators.py
+++ b/lazyflow/operators/classifierOperators.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 #		   http://ilastik.org/license/
 ###############################################################################
 #Python
-from abc import abstractmethod, ABC
+from abc import abstractmethod
 import copy
 import logging
 traceLogger = logging.getLogger("TRACE." + __name__)
@@ -390,7 +390,7 @@ class OpClassifierPredict(Operator):
         if slot == self.Classifier:
             self.PMaps.setDirty()
 
-class OpBaseClassifierPredict(Operator, ABC):
+class OpBaseClassifierPredict(Operator):
     Image = InputSlot()
     LabelsCount = InputSlot()
     Classifier = InputSlot()

--- a/lazyflow/operators/classifierOperators.py
+++ b/lazyflow/operators/classifierOperators.py
@@ -547,7 +547,6 @@ class OpVectorwiseClassifierPredict(OpBaseClassifierPredict):
 
         with Timer() as features_timer:
             input_data = self.Image[newKey].wait()
-        logger.debug(f"Features took {features_timer.seconds()} seconds for roi {roi}")
 
         input_data = numpy.asarray(input_data, numpy.float32)
         shape=input_data.shape
@@ -557,7 +556,9 @@ class OpVectorwiseClassifierPredict(OpBaseClassifierPredict):
         classifier = self.Classifier.value
         with Timer() as prediction_timer:
             probabilities = classifier.predict_probabilities( features )
-        logger.debug(f"  Prediction took {prediction_timer.seconds()} seconds for roi {roi}")
+
+        logger.debug(f"Features took {features_timer.seconds()} seconds."
+                     f" Prediction took {prediction_timer.seconds()} seconds. {roi}")
 
         probabilities.shape = shape[:-1] + (probabilities.shape[-1],)
         return probabilities

--- a/lazyflow/operators/classifierOperators.py
+++ b/lazyflow/operators/classifierOperators.py
@@ -438,6 +438,7 @@ class OpBaseClassifierPredict(Operator):
             skip_prediction = not numpy.any(mask)
 
         if skip_prediction:
+            logger.debug(f"Skipping masked block {roi}")
             result[:] = 0.0
             return result
 
@@ -547,7 +548,7 @@ class OpVectorwiseClassifierPredict(OpBaseClassifierPredict):
 
         with Timer() as features_timer:
             input_data = self.Image[newKey].wait()
-        logger.debug(f"Features took {features_timer.seconds()} seconds")
+        logger.debug(f"Features took {features_timer.seconds()} seconds for roi {roi}")
 
         input_data = numpy.asarray(input_data, numpy.float32)
         shape=input_data.shape
@@ -557,7 +558,7 @@ class OpVectorwiseClassifierPredict(OpBaseClassifierPredict):
         classifier = self.Classifier.value
         with Timer() as prediction_timer:
             probabilities = classifier.predict_probabilities( features )
-        logger.debug(f"Prediction took {prediction_timer.seconds()} seconds")
+        logger.debug(f"  Prediction took {prediction_timer.seconds()} seconds for roi {roi}")
 
         probabilities.shape = shape[:-1] + (probabilities.shape[-1],)
         return probabilities

--- a/lazyflow/operators/classifierOperators.py
+++ b/lazyflow/operators/classifierOperators.py
@@ -507,11 +507,10 @@ class OpPixelwiseClassifierPredict(OpBaseClassifierPredict):
         input_channels = self.Image.meta.shape[-1]
         upstream_roi[:,-1] = [0, input_channels]
 
-        return self.Image(*upstream_roi).wait()
-
+        input_data = self.Image(*upstream_roi).wait()
         axistags = self.Image.meta.axistags
-        classifier = self.Classifier.value
-        return classifier.predict_probabilities_pixelwise( raw_data_block, predictions_roi, axistags )
+        probabilities = classifier.predict_probabilities_pixelwise( input_data, predictions_roi, axistags )
+        return probabilities
 
 class OpVectorwiseClassifierPredict(OpBaseClassifierPredict):
     def setupOutputs(self):


### PR DESCRIPTION
# Refining the code for the Op*ClassificationPredict operators.

The Op*ClassificationPredict operators are able to handle masks to determine whether computation was needed on a roi during Pixel Classification. This PR re-applies the mask after the computation is done, so that the user will only get positive predictions  in the areas of the image that are not masked out.

Also, I've removed some of the code replication by moving common logic present in both OpPixelwiseClassifierPredict and OpVectorwiseClassifierPredict into a generic base class.

TODO: It's possible that we could optimize the code some more since we're still calculating features and predicitons for all pixels even if the roi is mostly made out of masked pixels.