### PR TITLE
Parallelize multi-page TIFF export

### DIFF
--- a/lazyflow/operators/ioOperators/opExportMultipageTiff.py
+++ b/lazyflow/operators/ioOperators/opExportMultipageTiff.py
@@ -17,246 +17,265 @@
 # See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
 # GNU Lesser General Public License version 2.1 and 3 respectively.
 # This information is also available on the ilastik web site at:
-#		   http://ilastik.org/license/
+# 		   http://ilastik.org/license/
 ###############################################################################
-from __future__ import division
-from __future__ import print_function
-#from future import standard_library
-#standard_library.install_aliases()
-from builtins import zip
-from builtins import next
-#
-from builtins import range
-import os
-import collections
-
-import numpy
-import psutil
-
-import vigra
-import tifffile
-
-from lazyflow.graph import Operator, InputSlot
-from lazyflow.utility import OrderedSignal
-from lazyflow.operators.opReorderAxes import OpReorderAxes
 
 import logging
+import pathlib
+import textwrap
+import uuid
+import xml.etree.ElementTree as ET
+from typing import Any, Iterable, Sequence
+
+import numpy as np
+import psutil
+import tifffile
+import vigra
+
+from lazyflow.graph import InputSlot, Operator
+from lazyflow.operators.opReorderAxes import OpReorderAxes
+from lazyflow.utility import OrderedSignal, RoiRequestBatch
+
 logger = logging.getLogger(__name__)
 
+
 class OpExportMultipageTiff(Operator):
-    Input = InputSlot() # The last two non-singleton axes (except 'c') are the axes of the 'pages'.
-                        # Re-order the axes yourself if you want an alternative slicing direction
+    """Export to multi-page OME-TIFF.
+
+    Attributes:
+        Input: Image data source (input slot).
+        Filepath: Path to the exported image (input slot).
+        progressSignal: Subscribe to this signal to receive export progress updates.
+    """
+
+    Input = InputSlot()
     Filepath = InputSlot()
 
-    DEFAULT_BATCH_SIZE = 4
+    _DEFAULT_BATCH_SIZE = 4
+    # OME-TIFF requires 5D with arbitrary order.
+    _EXPORT_AXES = "tzcyx"
 
     def __init__(self, *args, **kwargs):
-        super(OpExportMultipageTiff, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
+
         self.progressSignal = OrderedSignal()
+
         self._opReorderAxes = OpReorderAxes(parent=self)
-        self._opReorderAxes.Input.connect( self.Input )
+        self._opReorderAxes.Input.connect(self.Input)
+        self._opReorderAxes.AxisOrder.setValue(self._EXPORT_AXES)
+
+        self._page_buf = None
 
     def setupOutputs(self):
-        # Always export in tzcyx order
-        # (OME-TIFF doesn't require a particular order, but does require exactly 5D.)
-        self._opReorderAxes.AxisOrder.setValue('tzcyx')
-        self._export_axes = 'tzcyx'
+        pass
 
-    def run_export(self):
-        """
-        Request the volume in slices (running in parallel), and write each slice to the correct page.
-        Note: We can't use BigRequestStreamer here, because the data for each slice wouldn't be 
-              guaranteed to arrive in the correct order.
-        """
-        # Delete existing image if present
-        image_path = self.Filepath.value
-        if os.path.exists(image_path):
-            os.remove(image_path)
+    def execute(self, slot, subindex, roi, result):
+        pass
 
-        tagged_shape = self.Input.meta.getTaggedShape()
-        export_shape = self._opReorderAxes.Output.meta.shape
-        shape_yx = export_shape[-2:]
-        stacked_axes_shape = export_shape[:-2]
-        num_pages = numpy.prod(stacked_axes_shape)
+    def propagateDirty(self, slot, subindex, roi):
+        pass
 
-        def create_slice_req():
-            for stacked_axes_ndindex in numpy.ndindex(*stacked_axes_shape):
-                roi = numpy.zeros( (2,) + (len(export_shape),), dtype=int )
-                roi[:, :-2] = stacked_axes_ndindex
-                roi[1, :-2] += 1
-                roi[1, -2:] = shape_yx
-                yield self._opReorderAxes.Output(*roi)
-        iter_slice_requests = create_slice_req()
+    def run_export(self) -> None:
+        """Export an image from Input to Filepath."""
+        path = pathlib.Path(self.Filepath.value)
+        if path.exists():
+            path.unlink()
 
-        parallel_requests = self.DEFAULT_BATCH_SIZE
-        
-        # If ram usage info is available, make a better guess about how many requests we can launch in parallel
-        ram_usage_per_requested_pixel = self.Input.meta.ram_usage_per_requested_pixel
-        if ram_usage_per_requested_pixel is not None:
-            pixels_per_slice = numpy.prod(shape_yx)
-            if 'c' in tagged_shape:
-                pixels_per_slice //= tagged_shape['c']
-            
-            ram_usage_per_slice = pixels_per_slice * ram_usage_per_requested_pixel
+        self._page_buf = _NdBuf(self._opReorderAxes.Output.meta.shape[:-2])
 
-            # Fudge factor: Reduce RAM usage by a bit
-            available_ram = psutil.virtual_memory().available
-            available_ram *= 0.5
+        batch = RoiRequestBatch(
+            outputSlot=self._opReorderAxes.Output,
+            roiIterator=_page_rois(*self._opReorderAxes.Output.meta.shape),
+            totalVolume=np.prod(self._opReorderAxes.Output.meta.shape),
+            batchSize=self._batch_size,
+        )
+        batch.progressSignal.subscribe(self.progressSignal)
+        batch.resultSignal.subscribe(self._write_buffered_pages)
+        batch.execute()
 
-            parallel_requests = int(available_ram // ram_usage_per_slice)
-        
-        # Start with a batch of images
-        reqs = collections.deque()
-        for next_request_index in range( min(parallel_requests, num_pages) ):
-            reqs.append( next(iter_slice_requests) )
-        
-        self.progressSignal(0)
-        pages_written = 0
-        while reqs:
-            self.progressSignal( 100*next_request_index // num_pages )
-            req = reqs.popleft()
-            slice_data = req.wait()
-            slice_data = vigra.taggedView(slice_data, self._export_axes)
-            next_request_index += 1
-            
-            # Add a new request to the batch
-            if next_request_index < num_pages:
-                reqs.append( next(iter_slice_requests) )
-            
-            if pages_written == 0:
-                xml_description = OpExportMultipageTiff.generate_ome_xml_description(
-                                     self._opReorderAxes.Output.meta.getAxisKeys(),
-                                     self._opReorderAxes.Output.meta.shape,
-                                     self._opReorderAxes.Output.meta.dtype,
-                                     os.path.split(image_path)[1] )
-                # Write the first slice with tifffile, which allows us to write the tags.
-                with tifffile.TiffWriter( image_path, software='ilastik', byteorder='<' ) as writer:
-                    writer.save( slice_data.withAxes('yx'), description=xml_description, planarconfig='planar')
+    def _write_buffered_pages(self, roi, page) -> None:
+        """Store a new page in the buffer and write all in-order buffered pages to the file."""
+        page_axes = self._EXPORT_AXES[-2:]
+        page = vigra.taggedView(page, self._EXPORT_AXES).withAxes(page_axes)
+
+        page_idx = roi[0][:-2]
+        self._page_buf[page_idx] = page
+
+        for i, page in self._page_buf:
+            if not i:
+                self._write_first_page(page)
             else:
-                # Append a slice to the multipage tiff file
-                vigra.impex.writeImage( slice_data.withAxes('yx'), image_path, dtype='', compression='NONE', mode='a' )
-            pages_written += 1
+                vigra.impex.writeImage(page, self.Filepath.value, dtype="", compression="NONE", mode="a")
 
-        self.progressSignal(100)
+    def _write_first_page(self, page) -> None:
+        """Write the first page differently: it needs the OME-XML `ImageDescription` field."""
+        dtype = self._opReorderAxes.Output.meta.dtype
+        if isinstance(dtype, type):
+            dtype = dtype().dtype
 
-    # No output slots...
-    def execute(self, slot, subindex, roi, result): pass 
-    def propagateDirty(self, slot, subindex, roi): pass
+        desc = _image_desc_xml(
+            dtype=dtype,
+            axes=self._opReorderAxes.Output.meta.getAxisKeys(),
+            shape=self._opReorderAxes.Output.meta.shape,
+            file_uuid=str(uuid.uuid1()),
+            file_name=pathlib.Path(self.Filepath.value).name,
+        )
 
-    @classmethod
-    def generate_ome_xml_description(cls, axes, shape, dtype, filename=''):
-        """
-        Generate an OME XML description of the data we're exporting,
-        suitable for the image_description tag of the first page.
-
-        axes and shape should be provided in C-order (will be reversed in the XML)
-        """
-        import uuid
-        import xml.etree.ElementTree as ET
-
-        # Normalize the inputs
-        axes = "".join(axes)
-        shape = tuple(shape)
-        if not isinstance(dtype, type):
-            dtype = dtype().type
-
-        ome = ET.Element('OME')
-        uuid_str = "urn:uuid:" + str(uuid.uuid1())
-        ome.set('UUID', uuid_str)
-        ome.set('xmlns', 'http://www.openmicroscopy.org/Schemas/OME/2015-01')
-        ome.set('xmlns:xsi', "http://www.w3.org/2001/XMLSchema-instance")
-        ome.set('xsi:schemaLocation', 
-                "http://www.openmicroscopy.org/Schemas/OME/2015-01 "
-                "http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd")
-        
-        image = ET.SubElement(ome, 'Image')
-        image.set('ID', 'Image:0')
-        image.set('Name', 'exported-data')
-        
-        pixels = ET.SubElement(image, 'Pixels')
-        pixels.set('BigEndian', 'true')
-        pixels.set('ID', 'Pixels:0')
-
-        fortran_axes = "".join(reversed(axes)).upper()
-        pixels.set('DimensionOrder', fortran_axes)
-
-        for axis, dim in zip( axes.upper(), shape ):
-            pixels.set('Size'+axis, str(dim))
-
-        types = { numpy.uint8  : 'uint8', 
-                  numpy.uint16 : 'uint16', 
-                  numpy.uint32 : 'uint32', 
-                  numpy.int8   : 'int8', 
-                  numpy.int16  : 'int16', 
-                  numpy.int32  : 'int32', 
-                  numpy.float32  : 'float', 
-                  numpy.float64  : 'double', 
-                  numpy.complex64  : 'complex', 
-                  numpy.complex128  : 'double-complex' }
-
-        pixels.set('Type', types[dtype])
-        
-        ## Omit channel info for now
-        #channel0 = ET.SubElement(pixels, "Channel")
-        #channel0.set("ID", "Channel0:0")
-        #channel0.set("SamplesPerPixel", "1")
-        #channel0.append(ET.Element("LightPath"))
-
-        assert axes[-2:] == "yx"
-        for page_index, page_ndindex in enumerate(numpy.ndindex(*shape[:-2])):
-            tiffdata = ET.SubElement(pixels, "TiffData")
-            for axis, index in zip(axes[:-2].upper(), page_ndindex):
-                tiffdata.set("First"+axis, str(index))
-            tiffdata.set("PlaneCount", "1")
-            tiffdata.set("IFD", str(page_index))
-            uuid_tag = ET.SubElement(tiffdata, "UUID")
-            uuid_tag.text = uuid_str
-            uuid_tag.set('FileName', filename)
-
-        from textwrap import dedent
-        import sys
-        import io
-        xml_stream = io.BytesIO()
-        #if sys.version_info.major == 2:
-        #    xml_stream = io.BytesIO()
-        #else:
-        #    xml_stream = io.StringIO()
-
-        comment = ET.Comment(
-            ' Warning: this comment is an OME-XML metadata block, which contains crucial '
-            'dimensional parameters and other important metadata. Please edit cautiously '
-            '(if at all), and back up the original data before doing so. For more information, '
-            'see the OME-TIFF web site: http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/. ')
-        ET.ElementTree(comment).write(xml_stream, encoding='utf-8', xml_declaration=True)
-        
-        tree = ET.ElementTree(ome)
-        tree.write(xml_stream, encoding='utf-8', xml_declaration=False)
-        
         if logger.isEnabledFor(logging.DEBUG):
             import xml.dom.minidom
-            reparsed = xml.dom.minidom.parseString(xml_stream.getvalue())
-            logger.debug("Generated OME-TIFF metadata:\n" + reparsed.toprettyxml())
 
-        return xml_stream.getvalue()
+            pretty_desc = xml.dom.minidom.parseString(desc).toprettyxml()
+            logger.debug(f"Generated OME-TIFF metadata:\n{pretty_desc}")
+
+        with tifffile.TiffWriter(self.Filepath.value, software="ilastik", byteorder="<") as writer:
+            writer.save(page, description=desc, planarconfig="planar")
+
+    @property
+    def _batch_size(self) -> int:
+        bytes_per_pixel = self.Input.meta.ram_usage_per_requested_pixel
+        if not bytes_per_pixel:
+            return self._DEFAULT_BATCH_SIZE
+
+        shape = self._opReorderAxes.Output.meta.shape
+
+        nchannels = self.Input.meta.getTaggedShape().get("c", 1)
+        pixels_per_page = np.prod(shape[-2:]) // nchannels
+        bytes_per_page = bytes_per_pixel * pixels_per_page
+
+        total_bytes = psutil.virtual_memory().available // 2
+        batch_size = total_bytes // bytes_per_page
+
+        npages = np.prod(shape[:-2])
+        return min(batch_size, npages)
+
+
+class _NdBuf:
+    """Store ND-indexed items and give them back in the strict ND-ascending order."""
+
+    def __init__(self, shape: Iterable[int]):
+        self._items = {}
+        self._index = 0
+        self._shape = tuple(shape)
+
+    def __setitem__(self, key: Iterable[int], value: Any):
+        i = np.ravel_multi_index(key, self._shape)
+        self._items[i] = value
+
+    def __iter__(self) -> Iterable[Any]:
+        while self._index in self._items:
+            i = self._index
+            item = self._items.pop(i)
+            self._index += 1
+            yield i, item
+
+
+def _page_rois(*shape: int):
+    """Yield ROIs matching the TIFF pages from the input image shape."""
+    for page_idx in np.ndindex(*shape[:-2]):
+        start = page_idx + (0, 0)
+        stop = tuple(i + 1 for i in page_idx) + shape[-2:]
+        yield start, stop
+
+
+def _image_desc_xml(*, dtype: np.dtype, axes: Sequence[str], shape: Sequence[int], file_uuid="", file_name="") -> str:
+    """Create XML string for the OME-TIFF `ImageDescription` field."""
+    ome_types = {
+        "B": "uint8",
+        "H": "uint16",
+        "I": "uint32",
+        "b": "int8",
+        "h": "int16",
+        "i": "int32",
+        "f": "float",
+        "d": "double",
+        "F": "complex",
+        "D": "double-complex",
+    }
+    ome_type = ome_types.get(dtype.char)
+    if ome_type is None:
+        raise ValueError(f"dtype {dtype.name} does not have a matching OME-XML type")
+
+    if len(axes) != len(shape):
+        raise ValueError(f"axes and shape have different lengths: {len(axes)} != {len(shape)}")
+    if len(axes) < 2:
+        raise ValueError(f"expected at least 2 dimensions, got {len(axes)}")
+    # OME-XML uses Fortran order.
+    dims = "".join(reversed(axes)).upper()
+    sizes = tuple(reversed(shape))
+
+    if file_name and not file_uuid:
+        raise ValueError("file_name requires file_uuid")
+
+    ome = ET.Element("OME")
+    ome.set("xmlns", "http://www.openmicroscopy.org/Schemas/OME/2015-01")
+    ome.set("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
+    ome.set(
+        "xsi:schemaLocation",
+        "http://www.openmicroscopy.org/Schemas/OME/2015-01 "
+        "http://www.openmicroscopy.org/Schemas/OME/2015-01/ome.xsd",
+    )
+    if file_uuid:
+        ome.set("UUID", f"urn:uuid:{file_uuid}")
+
+    image = ET.SubElement(ome, "Image")
+    image.set("ID", "Image:0")
+    image.set("Name", "exported-data")
+
+    pixels = ET.SubElement(image, "Pixels")
+    pixels.set("ID", "Pixels:0")
+    pixels.set("BigEndian", "true")  # TODO: Figure out what endianness we actually use.
+    pixels.set("Type", ome_type)
+    pixels.set("DimensionOrder", dims)
+    for dim, size in zip(dims, sizes):
+        pixels.set(f"Size{dim}", str(size))
+
+    npages = np.prod(sizes[2:])
+    for i in range(npages):
+        tiff_data = ET.SubElement(pixels, "TiffData")
+        tiff_data.set("PlaneCount", "1")
+        tiff_data.set("IFD", str(i))
+
+        offsets = ()
+        if npages > 1:
+            offsets = np.unravel_index(i, sizes[2:], order="F")
+        for dim, offset in zip(dims[2:], offsets):
+            tiff_data.set(f"First{dim}", str(offset))
+
+        if file_uuid:
+            uuid_elem = ET.SubElement(tiff_data, "UUID")
+            uuid_elem.text = ome.get("UUID")
+            if file_name:
+                uuid_elem.set("FileName", file_name)
+
+    header = textwrap.dedent(
+        """\
+        <?xml version="1.0" encoding="utf-8"?>
+        <!-- Warning: this comment is an OME-XML metadata block, which contains
+        crucial dimensional parameters and other important metadata. Please edit
+        cautiously (if at all), and back up the original data before doing so.
+        For more information, see the OME-TIFF documentation:
+        https://docs.openmicroscopy.org/latest/ome-model/ome-tiff/ -->
+        """
+    )
+    return header + ET.tostring(ome, encoding="unicode")
+
 
 if __name__ == "__main__":
     import sys
-    logger.addHandler( logging.StreamHandler(sys.stdout) )
+
+    logger.addHandler(logging.StreamHandler(sys.stdout))
     logger.setLevel(logging.DEBUG)
-    
+
     from lazyflow.graph import Graph
     from lazyflow.operators.ioOperators import OpTiffReader
-    
+
     graph = Graph()
-    opReader = OpTiffReader( graph=graph )
-    opReader.Filepath.setValue( '/tmp/xyz.ome.tiff' )
-    
+    opReader = OpTiffReader(graph=graph)
+    opReader.Filepath.setValue("/tmp/xyz.ome.tiff")
+
     opWriter = OpExportMultipageTiff(graph=graph)
-    opWriter.Filepath.setValue( '/tmp/xyz-converted.ome.tiff' )
-    opWriter.Input.connect( opReader.Output )
-    
+    opWriter.Filepath.setValue("/tmp/xyz-converted.ome.tiff")
+    opWriter.Input.connect(opReader.Output)
+
     opWriter.run_export()
     print("DONE.")
-
-
- 

--- a/lazyflow/utility/__init__.py
+++ b/lazyflow/utility/__init__.py
@@ -47,3 +47,4 @@ from .priorityQueue import PriorityQueue
 from .log_exception import log_exception
 from .transposed_view import TransposedView
 from .reorderAxesDecorator import reorder_options, reorder
+from .pipeline import Pipeline

--- a/lazyflow/utility/pipeline.py
+++ b/lazyflow/utility/pipeline.py
@@ -1,0 +1,109 @@
+###############################################################################
+#   lazyflow: data flow based lazy parallel computation framework
+#
+#       Copyright (C) 2011-2014, the ilastik developers
+#                                <team@ilastik.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the Lesser GNU General Public License
+# as published by the Free Software Foundation; either version 2.1
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# See the files LICENSE.lgpl2 and LICENSE.lgpl3 for full text of the
+# GNU Lesser General Public License version 2.1 and 3 respectively.
+# This information is also available on the ilastik web site at:
+# 		   http://ilastik.org/license/
+###############################################################################
+
+from collections import abc
+from typing import Any, Callable
+
+from lazyflow.operator import Operator
+from lazyflow.slot import Slot
+
+
+class Pipeline(abc.Sequence):
+    """Connect operators in a linear chain.
+
+    Each operator in the pipeline should have an input slot named "Input" and an output slot named "Output",
+    with the exception of the first operator (no "Input" required) and the last operator (no "Output" required).
+    For every operator in the pipeline except the first one, it's slot named "Input" gets connected
+    to the slot named "Output" of the previous operator.
+
+    Examples:
+        >>> graph = Graph()
+        >>> opSideways = OpSideways(graph=graph)
+        >>> with Pipeline(graph=graph) as pipeline:
+        ...     pipeline.add(StartOp, Input="spam")
+        ...     pipeline.add(MiddleOp, SomeFlag=True)
+        ...     pipeline.add(FinalOp, OtherConnection=opSideways.Output)
+        ...     pipeline[-1].Output[:].wait()
+    """
+
+    def __init__(self, **op_init_kwargs: Any):
+        """Create a new, empty pipeline.
+
+        Args:
+            **op_init_kwargs: Keyword arguments passed to ``opfunc`` in :meth:`add`.
+        """
+        self._op_init_kwargs = op_init_kwargs
+        self._ops = []
+
+    def add(self, opfunc: Callable[..., Operator], **slots: Any) -> Operator:
+        """Add a new operator to the end of this pipeline.
+
+        The operator instance is created with the ``**op_init_kwargs`` previously passed to ``__init__``,
+        it's "Input" gets connected to "Output" of previous operator (if it exists), and it's other input slots
+        are configured, based on the contents of `**slots``.
+        For each argument in `**slots`, it's name is used as a name of the input slot of the new operator,
+        and, if a value of that argument is a :class:`Slot`, it is connected to the new operator
+        with :meth:`Operator.connect`. Otherwise, :meth:`Operator.setValue` is used.
+
+        Args:
+            opfunc: Callable used to create a new operator.
+            **slots: values or output slots that get assigned to the new operator.
+
+        Returns:
+            The new, configured operator.
+        """
+        op = opfunc(**self._op_init_kwargs)
+
+        if self:
+            if "Input" is slots:
+                raise ValueError('slot with the name "Input" cannot be manually assigned for non-first operator')
+            if not hasattr(op, "Input"):
+                raise ValueError(f'new operator {op} does not have a slot with the name "Input"')
+            if not hasattr(self[-1], "Output"):
+                raise ValueError(f'previous operator {self[-1]} does not have a slot with the name "Output"')
+            op.Input.connect(self[-1].Output)
+
+        for name, value in slots.items():
+            if isinstance(value, Slot):
+                op.inputs[name].connect(value)
+            else:
+                op.inputs[name].setValue(value)
+
+        self._ops.append(op)
+        return op
+
+    def close(self) -> None:
+        """Cleanup all operators in this pipeline in the LIFO order."""
+        for op in reversed(self):
+            op.cleanUp()
+
+    def __getitem__(self, item: int) -> Operator:
+        return self._ops.__getitem__(item)
+
+    def __len__(self) -> int:
+        return self._ops.__len__()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/tests/testOpExportMultipageTiff.py
+++ b/tests/testOpExportMultipageTiff.py
@@ -20,48 +20,18 @@
 # 		   http://ilastik.org/license/
 ###############################################################################
 
-import contextlib
 import pathlib
 import tempfile
-from typing import Any, Callable
 
 import numpy
 import vigra
 
 from lazyflow.graph import Graph
-from lazyflow.operator import Operator
 from lazyflow.operators.ioOperators import OpExportMultipageTiff
 from lazyflow.operators.ioOperators.opTiffReader import OpTiffReader
 from lazyflow.operators.opArrayPiper import OpArrayPiper
 from lazyflow.operators.opReorderAxes import OpReorderAxes
-
-
-class _Pipeline:
-    def __init__(self, **op_init_kwargs):
-        self._op_init_kwargs = op_init_kwargs
-        self._ops = []
-
-    def append(self, op_callable: Callable[..., Operator], **value_slots: Any) -> None:
-        op = op_callable(**self._op_init_kwargs)
-        for name, value in value_slots.items():
-            if self and name == "Input":
-                raise ValueError(
-                    'Setting value of the input slot "Input" is allowed only for the first operator in the pipeline'
-                )
-            op.inputs[name].setValue(value)
-        if self:
-            op.Input.connect(self[-1].Output)
-        self._ops.append(op)
-
-    def __len__(self) -> int:
-        return self._ops.__len__()
-
-    def __getitem__(self, item: int) -> Operator:
-        return self._ops.__getitem__(item)
-
-    def close(self) -> None:
-        for op in reversed(self._ops):
-            op.cleanUp()
+from lazyflow.utility import Pipeline
 
 
 def test_OpExportMultipageTiff():
@@ -75,16 +45,14 @@ def test_OpExportMultipageTiff():
         filepath = str(pathlib.Path(tempdir, "multipage.tiff"))
         graph = Graph()
 
-        write_tiff = _Pipeline(graph=graph)
-        write_tiff.append(OpArrayPiper, Input=expected)
-        write_tiff.append(OpExportMultipageTiff, Filepath=filepath)
-        with contextlib.closing(write_tiff):
+        with Pipeline(graph=graph) as write_tiff:
+            write_tiff.add(OpArrayPiper, Input=expected)
+            write_tiff.add(OpExportMultipageTiff, Filepath=filepath)
             write_tiff[-1].run_export()
 
-        read_tiff = _Pipeline(graph=graph)
-        read_tiff.append(OpTiffReader, Filepath=filepath)
-        read_tiff.append(OpReorderAxes, AxisOrder=axes)
-        with contextlib.closing(read_tiff):
+        with Pipeline(graph=graph) as read_tiff:
+            read_tiff.add(OpTiffReader, Filepath=filepath)
+            read_tiff.add(OpReorderAxes, AxisOrder=axes)
             actual = read_tiff[-1].Output[:].wait().astype(dtype)
 
     numpy.testing.assert_array_equal(expected, actual)


### PR DESCRIPTION
Previously, OpExportMultipageTiff.run_export() requested pages
sequentially. Although each submitted request eventually triggered
parallel computations, at the end of each request threads were idle
because of the sequential step in the run_export().

This commit uses RoiRequestBatch to request multiple pages in parallel.
Because pages have to be written in order, the current implementation
maintains a page buffer that saves out-of-order pages in memory until it
can release a contiguous sequence of pages. This approach can
potentially blow up memory, but very unlikely to happen because the
workload is uniform across requests, and pages are requested in-order.

The other alternative is to write pages as they arrive, and later
specify their order in the OME-XML ImageDescription field. However, this
requires patching the TIFF file field after the data has been written.,
which is more error-prone to implement and maintain.

Exporting probability map as normalized uint8 image from a 572M file [1]
containing 1600x1200 pixels, 3 channels and 104 time points gave
1.28x speedup from 739 to 578 seconds for run_export().

Measuring page request computation time and comparing it to the page
I/O time showed that the page I/O constitutes 0.7% of the total page
processing time: 3.063 mean seconds for page request vs. 0.022
mean seconds for the page I/O.

System: Dell XPS 15 9570
CPU: Intel Core i7-8750H (6 cores, 12 threads)
RAM: 16GB
OS: Ubuntu 18.04
Disk: NVMe

[1]: http://data.ilastik.org/pixel-classification/3d/MC0509C3X100-2.tif