### PR TITLE
Adds Input and AxisOrder to OpReorderAxes' constructor

### DIFF
--- a/lazyflow/operators/opReorderAxes.py
+++ b/lazyflow/operators/opReorderAxes.py
@@ -36,15 +36,13 @@ logger = logging.getLogger(__name__)
 
 class OpReorderAxes(Operator):
     Input = InputSlot()
-    AxisOrder = InputSlot(value='tzyxc') # string: The desired output axis order
+    AxisOrder = InputSlot() # string: The desired output axis order
     Output = OutputSlot()
 
-    def __init__(self, graph=None, parent=None, Input=None, AxisOrder=None):
+    def __init__(self, graph=None, parent=None, Input=None, AxisOrder='tzyxc'):
         super().__init__(graph=graph, parent=parent)
-        if Input is not None:
-            self.Input.connect(Input)
-        if AxisOrder is not None:
-            self.AxisOrder.setValue(AxisOrder)
+        self.Input.setOrConnectIfAvailable(Input)
+        self.AxisOrder.setOrConnectIfAvailable(AxisOrder)
 
     def setupOutputs(self):
         if 'c' not in self.AxisOrder.value:

--- a/lazyflow/operators/opReorderAxes.py
+++ b/lazyflow/operators/opReorderAxes.py
@@ -39,6 +39,13 @@ class OpReorderAxes(Operator):
     AxisOrder = InputSlot(value='tzyxc') # string: The desired output axis order
     Output = OutputSlot()
 
+    def __init__(self, graph=None, parent=None, Input=None, AxisOrder=None):
+        super().__init__(graph=graph, parent=parent)
+        if Input is not None:
+            self.Input.connect(Input)
+        if AxisOrder is not None:
+            self.AxisOrder.setValue(AxisOrder)
+
     def setupOutputs(self):
         if 'c' not in self.AxisOrder.value:
             # This is helpful in order to convert our internal axis order to 'tczyx'

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -483,6 +483,17 @@ class Slot(object):
             self.meta._ready = False
             self._sig_unready(self)
 
+    def setOrConnect(self, value_or_slot):
+        if isinstance(value_or_slot, Slot):
+            self.connect(value_or_slot)
+        else:
+            self.setValue(value_or_slot)
+
+    def setOrConnectIfAvailable(self, value_or_slot):
+        if value_or_slot is None:
+            return
+        self.setOrConnect(value_or_slot)
+
     @is_setup_fn
     def connect(self, upstream_slot, notify=True, permit_distant_connection=False):
         """

--- a/tests/testOpReorderAxes.py
+++ b/tests/testOpReorderAxes.py
@@ -80,6 +80,8 @@ class TestOpReorderAxes(unittest.TestCase):
             self.operator = OpReorderAxes(graph=self.graph, Input=opProvider.Output, AxisOrder=AxisOrder)
         else:
             self.operator.Input.connect(opProvider.Output)
+            if AxisOrder is not None:
+                self.operator.AxisOrder.setValue(AxisOrder)
 
     def test_Full(self):
         for i in range(self.tests):
@@ -155,11 +157,9 @@ class TestOpReorderAxes(unittest.TestCase):
         
     def _impl_roi_custom_order(self, axisorder):
         for i in range(self.tests):
-            use_constructor = bool(i%2)
+            config_via_init = bool(i%2)
             # Specify a strange order for the output axis tags
-            self.prepareVolnOp(axisorder, len(axisorder)-1, AxisOrder=axisorder, config_via_init=use_constructor)
-            if not use_constructor:
-                self.operator.AxisOrder.setValue(axisorder)
+            self.prepareVolnOp(axisorder, len(axisorder)-1, AxisOrder=axisorder, config_via_init=config_via_init)
 
             shape = self.operator.Output.meta.shape
 


### PR DESCRIPTION
Creates a more sensible constructor for OpReorderAxes, so that you can spawn it already configured and ready to go.

This is the first step towards having sensible operator constructors in Lazyflow, so that we can actually spawn operators that are ready to do their job and that, hopefully, are never inconsistent. This would eventually mean that `operator.configured()` would always be `True`. This change is convenient for the code cleanups that are coming in the object classification workflow, but those are in the ilastik project.

Right now operator construction is meaningless; one can do `OpReorderAxes()` and receive back an operator with dangling inputs. In fact, the programmer can even forget to set up those inputs, and be faced with the most common and most annoying exception in ilastik: `SlotNotReady`. Furthermore, doing this:
```
op5 = OpReorderAxes()
op5.AxisOrder = 'xyz'
op5.Input.connect(opWhatever.Output)
```
is far more inconvenient and error prone than simply

```
op5 = OpReorderAxes(AxisOrder='xyz', Input=opWhatever.Output)
```

not to mention that the first style can have more unpredictable `setupOutputs()` firings and somewhat violates the operator's encapsulation.

The idea is to eventually have operators that take all of their inputs in the constructor, so that it is instantiated in a consistent state, and then only allow the state to be modified in a transaction-like style (or maybe not allow it to be modified at all). Though this could be potentially done in the root `Operator` class by scanning `**kwargs` for operator names, I'd rather have the inputs explicitly defined in the constructor arguments so that the code is easier to follow (one can immediately see what can be passed into the operator and we can have type hints for every parameter).

