### PR TITLE
Mask/Atlas: Fixes mask being applied as int rather than bool

### DIFF
--- a/lazyflow/operators/classifierOperators.py
+++ b/lazyflow/operators/classifierOperators.py
@@ -467,7 +467,7 @@ class OpBaseClassifierPredict(Operator):
             multichannel_mask = self.PredictionMask(start, stop).wait()
 
             # create a single-channel merged mask, which has 0 iff all PredictionMask channels are 0
-            mask = multichannel_mask[..., 0:1]
+            mask = multichannel_mask[..., 0:1] > 0
             for c in range(1, num_channels_in_mask):
                 mask = numpy.logical_or(mask, multichannel_mask[..., c : c + 1])
 


### PR DESCRIPTION
When using single-channel masks or atlases, it's value was being applied onto the predictions as int (thus multiplying) rather than boolean values (thus masking).

This PR forces the mask into a boolean by setting it to `multichannel_mask[..., 0:1] > 0`, fixing the issue.