### PR TITLE
Sane tracebacks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,17 @@ import os
 
 import pytest
 
+from lazyflow.operator import format_operator_stack
 from lazyflow.graph import Graph
+
+
+@pytest.hookimpl()
+def pytest_exception_interact(node, call, report):
+    if call.excinfo:
+        stack = format_operator_stack(call.excinfo.tb)
+        if stack:
+            formatted_stack = "".join(stack)
+            report.sections.append(("Operator Stack", formatted_stack))
 
 
 @pytest.fixture(scope="session")

--- a/tests/testOperatorInterface.py
+++ b/tests/testOperatorInterface.py
@@ -34,6 +34,7 @@ from lazyflow import graph
 from lazyflow import stype
 from lazyflow import slot
 from lazyflow import operators
+from lazyflow import operator
 from lazyflow.graph import OperatorWrapper
 
 import numpy
@@ -821,6 +822,38 @@ class TestCompatibilityChecks:
     def test_arraylike_retun_non_arraylike_object_raises(self, op):
         with pytest.raises(stype.InvalidResult):
             assert op.OutputUnsupportedType.value
+
+
+class TestOperatorStackFormatter:
+    class BrokenOp(operator.Operator):
+        Out = slot.OutputSlot()
+
+        def setupOutputs(self):
+            self.Out.meta.shape = (1,)
+            self.Out.meta.dtype = object
+
+        def execute(self, *args, **kwargs):
+            raise Exception()
+
+        def propagateDirty(self, *args, **kwargs):
+            pass
+
+    def test_operator_except_formatting(self):
+        op = self.BrokenOp(graph=graph.Graph())
+
+        exc = None
+
+        try:
+            op.Out.value
+        except Exception as e:
+            exc = e
+
+        assert exc
+
+        stack = operator.format_operator_stack(exc.__traceback__)
+        assert stack
+        assert len(stack) == 1
+        assert "TestOperatorStackFormatter.BrokenOp.execute" in stack[0]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added `Operator Stack` section to exceptions see examples [here](https://gist.github.com/m-novikov/6e6d3fb7d4fdb55c2ec0b5377846927d)
The section includes full operator class name + method and pointer to file:lineno