### PR TITLE
Mutlilevel slots should not implement operator interface

### DIFF
--- a/lazyflow/operator.py
+++ b/lazyflow/operator.py
@@ -399,9 +399,7 @@ class Operator(metaclass=OperatorMetaClass):
         for s in list(self.inputs.values()) + list(self.outputs.values()):
             # See note about the externally_managed flag in Operator.__init__
             downstream_slots = list(
-                p
-                for p in s.downstream_slots
-                if p.getRealOperator() is not None and not p.getRealOperator().externally_managed
+                p for p in s.downstream_slots if p.operator is not None and not p.operator.externally_managed
             )
             if len(downstream_slots) > 0:
                 msg = (
@@ -410,7 +408,7 @@ class Operator(metaclass=OperatorMetaClass):
                     " operators!\n".format(self.name, s.name)
                 )
                 for i, p in enumerate(s.downstream_slots):
-                    msg += "Downstream Partner {}: {}.{}".format(i, p.getRealOperator().name, p.name)
+                    msg += "Downstream Partner {}: {}.{}".format(i, p.operator.name, p.name)
                 raise RuntimeError(msg)
 
         self._parent = None

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -186,6 +186,9 @@ class Slot(object):
         :param nonlane: For multislot, this flag protects it from
           being considered lane-indexed
 
+        :param subindex: index within the parent slot
+
+        :param parent_slot: in case of multilevel slots slot on one level above
         """
         # This assertion is here for a reason: default values do NOT work on OutputSlots.
         # (We should probably change that at some point...)

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -1510,20 +1510,16 @@ class Slot(object):
         tmpshape[self.meta.axistags.index(axis)] = size
         self.meta.shape = tuple(tmpshape)
 
-    def __str__(self):
-        mslot_info = ""
-        if self.level > 0 or isinstance(self.operator, Slot):
-            mslot_info += "["
-            if isinstance(self.operator, Slot):
-                if self in self.operator._subSlots:
-                    mslot_info += " index={}".format(self.operator.index(self))
-                else:
-                    mslot_info += " index=NOTFOUND"
-            if self.level > 0:
-                mslot_info += " len={}".format(len(self))
-                if self.level > 1:
-                    mslot_info += " level={}".format(self.level)
-            mslot_info += " ] "
+    def __repr__(self):
+        mslot_info = []
+
+        if self.level > 0:
+            mslot_info.append(f"len={len(self)} level={self.level}")
+
+        if self.subindex:
+            mslot_info.append(f"index={self.subindex}")
+
+        mslot_info_str = ' '.join(mslot_info)
 
         # For debugging:
         # Should actually never happen if the operator is constructed correctly,
@@ -1533,10 +1529,7 @@ class Slot(object):
         else:
             realOpName = self.operator.name
 
-        return "{}.{} {}: \t{}".format(realOpName, self.name, mslot_info, self.meta)
-
-    def __repr__(self):
-        return self.__str__()
+        return f"{realOpName}.{self.name} [{mslot_info_str}]: \t{self.meta}"
 
 
 class InputSlot(Slot):

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -159,7 +159,7 @@ class Slot(object):
         level=0,
         nonlane=False,
         allow_mask=False,
-        subindex=None,
+        subindex=(),
         top_level_slot=None,
     ):
         """Constructor of the Slot class.
@@ -220,7 +220,7 @@ class Slot(object):
         # connected
         self.upstream_slot = None
         self.level = level
-        self.subindex = subindex or ()
+        self.subindex = subindex
         self._top_level_slot = top_level_slot
 
         # in the case of an InputSlot one can directly assign a value
@@ -1519,7 +1519,7 @@ class Slot(object):
         if self.subindex:
             mslot_info.append(f"index={self.subindex}")
 
-        mslot_info_str = ' '.join(mslot_info)
+        mslot_info_str = " ".join(mslot_info)
 
         # For debugging:
         # Should actually never happen if the operator is constructed correctly,

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -1068,7 +1068,7 @@ class Slot(object):
             # the chain
             self.setDirty(roi)
         if self._type == "input":
-            self.operator.setInSlot(self, (), roi, value)
+            self.operator.setInSlot(self.top_level_slot, self.subindex, roi, value)
 
         # Forward to downstream_slots
         for p in self.downstream_slots:
@@ -1076,23 +1076,6 @@ class Slot(object):
 
     def index(self, slot):
         return self._subSlots.index(slot)
-
-    @is_setup_fn
-    def setInSlot(self, slot, subindex, roi, value):
-        """For now, Slots of level > 0 pretend to be operators (as far
-        as their subslots are concerned). That's why they have to have
-        this setInSlot() method.
-
-        """
-        # If we do not support masked arrays, ensure that we are not being passed one.
-        assert self.allow_mask or not (self.meta.has_mask or isinstance(value, numpy.ma.masked_array)), (
-            'The operator, "%s", is being setup to receive a masked array as input to slot, "%s".'
-            " This is currently not supported." % (self.operator.name, self.name)
-        )
-        # Determine which subslot this is and prepend it to the totalIndex
-        totalIndex = (self._subSlots.index(slot),) + subindex
-        # Forward the call to our operator
-        self.operator.setInSlot(self, totalIndex, roi, value)
 
     def __len__(self):
         """In the case of a MultiSlot this returns the number of

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -263,8 +263,6 @@ class Slot(object):
 
         self._resizing = False
 
-        self._settingUp = False
-
         # Allow slots to be sorted by their order of creation for
         # debug output and diagramming purposes.
         self._global_slot_id = next(Slot._global_counter)

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -186,9 +186,9 @@ class Slot(object):
         :param nonlane: For multislot, this flag protects it from
           being considered lane-indexed
 
-        :param subindex: index within the parent slot
+        :param subindex: index within the top level slot
 
-        :param top_level_slot: in case of multilevel slots with highest level
+        :param top_level_slot: in case of multilevel slots a slot with the highest level
         """
         # This assertion is here for a reason: default values do NOT work on OutputSlots.
         # (We should probably change that at some point...)

--- a/lazyflow/tools/schematic.py
+++ b/lazyflow/tools/schematic.py
@@ -426,7 +426,7 @@ def get_column_within_parent(op):
     for slot in list(op.inputs.values()):
         if slot.upstream_slot is None:
             continue
-        upstream_op = slot.upstream_slot.getRealOperator()
+        upstream_op = slot.upstream_slot.operator
         if upstream_op is not op.parent and upstream_op is not op:
             assert upstream_op.parent is op.parent, (
                 "Slot '{}' of operator '{}' and it's upstream_slot"

--- a/tests/testOperatorInterface.py
+++ b/tests/testOperatorInterface.py
@@ -856,6 +856,22 @@ class TestOperatorStackFormatter:
         assert "TestOperatorStackFormatter.BrokenOp.execute" in stack[0]
 
 
+def test_operator_str():
+    g = graph.Graph()
+
+    class OpA(graph.Operator):
+        Input = graph.InputSlot(level=2)
+
+    op = OpA(graph=g)
+    op.Input.resize(2)
+
+    assert "level=1" in str(op.Input[0])
+    assert "index=(0,)" in str(op.Input[0])
+
+    assert "len=2" in str(op.Input)
+    assert "index" not in str(op.Input)
+
+
 if __name__ == "__main__":
     import sys
     import nose


### PR DESCRIPTION
Reasons:
* Reduces recursion depth
* Simplifies reasoning about the graph structure
