### PR TITLE
Fix paths with z5py1.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,3 @@ repos:
     rev: stable
     hooks:
     - id: black
-language_version: python3.6

--- a/lazyflow/utility/pathHelpers.py
+++ b/lazyflow/utility/pathHelpers.py
@@ -354,8 +354,7 @@ def lsH5N5(h5N5FileObject, minShape=2, maxShape=5):
             return
         if isinstance(h5N5FileObject, z5py.N5File):
             # make sure we get a path with forward slashes on windows
-            objectName = pathlib.Path(objectName)
-            objectName = objectName.relative_to(h5N5FileObject.path).as_posix()  # Need only the internal path here
+            objectName = pathlib.Path(objectName).as_posix()
         listOfDatasets.append({"name": objectName, "object": obj})
 
     h5N5FileObject.visititems(addObjectNames)


### PR DESCRIPTION
with a recent update of z5py, it now correctly returns internal paths only from `visiteditems`:

https://github.com/constantinpape/z5/commit/8ec2ff7555a034b49a2666f79e86707713c93164


requires `z5py>=1.5.1`