### PR TITLE
Fix scikit-learn classifier HDF5 serialization

### DIFF
--- a/lazyflow/classifiers/sklearnLazyflowClassifier.py
+++ b/lazyflow/classifiers/sklearnLazyflowClassifier.py
@@ -99,15 +99,14 @@ class SklearnLazyflowClassifier(LazyflowVectorwiseClassifierABC):
         return self._feature_names
 
     def serialize_hdf5(self, h5py_group):
-        h5py_group["pickled_classifier"] = pickle.dumps(self, 0)
+        h5py_group["pickled_classifier"] = numpy.void(pickle.dumps(self, 0))
 
         # This is a required field for all classifiers
-        h5py_group["pickled_type"] = pickle.dumps(type(self), 0)
+        h5py_group["pickled_type"] = numpy.void(pickle.dumps(type(self), 0))
 
     @classmethod
     def deserialize_hdf5(cls, h5py_group):
-        pickled = h5py_group["pickled_classifier"][()]
-        classifier = pickle.loads(pickled)
+        classifier = pickle.loads(h5py_group["pickled_classifier"][()].tostring())
         if not hasattr(classifier, "VERSION") or classifier.VERSION != cls.VERSION:
             raise cls.VersionIncompatibilityError(
                 "Version mismatch. Deserialized classifier version does not match this code base."


### PR DESCRIPTION
From https://h5py.readthedocs.io/en/stable/strings.html#how-to-store-raw-binary-data:

> If you have a non-text blob in a Python byte string (as opposed to
> ASCII or UTF-8 encoded text, which is fine), you should wrap it in a
> void type for storage. This will map to the HDF5 OPAQUE datatype, and
> will prevent your blob from getting mangled by the string machinery.
>
> Here’s an example of how to store binary data in an attribute, and
> then recover it:
>
>     binary_blob = b"Hello\x00Hello\x00"
>     dset.attrs["attribute_name"] = np.void(binary_blob)
>     out = dset.attrs["attribute_name"]
>     binary_blob = out.tostring()

Closes https://github.com/ilastik/ilastik/issues/1997.