### PR TITLE
Add factory function to create requests returning value

### DIFF
--- a/lazyflow/request/request.py
+++ b/lazyflow/request/request.py
@@ -1575,7 +1575,7 @@ class _ValueRequest:
             destination.data[...] = ma.getdata(self.result)
             destination.mask[...] = ma.getmaskarray(self.result)
             if isinstance(self.result, ma.masked_array):
-                destination.fill_value = self.result.fill_value
+                destination.set_fill_value(self.result.fill_value)
 
         elif isinstance(destination, collections.MutableSequence) or isinstance(
             self.result, collections.MutableSequence

--- a/lazyflow/request/request.py
+++ b/lazyflow/request/request.py
@@ -195,6 +195,13 @@ class Request(object):
 
     _root_request_counter = itertools.count()
 
+    @classmethod
+    def with_value(cls, value):
+        """
+        Create request returning specified value
+        """
+        return cls(lambda: value)
+
     def __init__(self, fn, root_priority=[0]):
         """
         Constructor.

--- a/lazyflow/request/request.py
+++ b/lazyflow/request/request.py
@@ -197,13 +197,6 @@ class Request(object):
 
     _root_request_counter = itertools.count()
 
-    @classmethod
-    def with_value(cls, value):
-        """
-        Create request returning specified value
-        """
-        return _ValueRequest(value)
-
     def __init__(self, fn, root_priority=[0]):
         """
         Constructor.
@@ -286,6 +279,17 @@ class Request(object):
                 self.uncancellable,
             )
         )
+
+    @classmethod
+    def with_value(cls, value):
+        """
+        Wraps specified value with Request like object
+
+        Example:
+        >>> Request.with_value(42).wait()
+        42
+        """
+        return _ValueRequest(value)
 
     def clean(self, _fullClean=True):
         """

--- a/tests/test_request/test_request.py
+++ b/tests/test_request/test_request.py
@@ -263,3 +263,11 @@ def test_cancels_child_requests(cancelled_work):
     work_rq = cancelled_work.request
 
     assert work_rq.child_requests == set()
+
+
+def test_request_with_value_factory():
+    req = Request.with_value(None)
+    assert req.wait() == None
+
+    req = Request.with_value(42)
+    assert req.wait() == 42

--- a/tests/test_request/test_request.py
+++ b/tests/test_request/test_request.py
@@ -265,9 +265,16 @@ def test_cancels_child_requests(cancelled_work):
     assert work_rq.child_requests == set()
 
 
-def test_request_with_value_factory():
-    req = Request.with_value(None)
-    assert req.wait() == None
+class TestRequestWithValue:
+    def test_return_value(self):
+        req = Request.with_value(None)
+        assert req.wait() == None
 
-    req = Request.with_value(42)
-    assert req.wait() == 42
+        req = Request.with_value(42)
+        assert req.wait() == 42
+
+    def test_notify_finished(self):
+        cb = mock.Mock()
+        req = Request.with_value(42)
+        req.notify_finished(cb)
+        cb.assert_called_once_with(42)

--- a/tests/test_request/test_request.py
+++ b/tests/test_request/test_request.py
@@ -1,10 +1,11 @@
 import time
 import threading
-
 from unittest import mock
 from functools import partial
 
 import pytest
+import numpy as np
+from numpy.testing import assert_array_equal
 
 from lazyflow.request.request import Request, SimpleSignal
 
@@ -278,3 +279,18 @@ class TestRequestWithValue:
         req = Request.with_value(42)
         req.notify_finished(cb)
         cb.assert_called_once_with(42)
+
+    def test_masked_array(self):
+        arr = np.ma.array([12, 10, 17], mask=[0, 0, 1], fill_value=42)
+
+        dst = np.ma.array([0, 0, 0], mask=False)
+
+        req = Request.with_value(arr)
+        req.writeInto(dst)
+
+        assert_array_equal(arr.data, dst.data)
+        assert_array_equal(arr.mask, dst.mask)
+
+        assert arr.get_fill_value() == dst.get_fill_value()
+        assert_array_equal(np.array([12, 10, 42]), arr.filled())
+        assert_array_equal(arr.filled(), dst.filled())


### PR DESCRIPTION
When we have a certain function that usually returns a Request, but in some cases, when it can't do any actual work and should fallback to just returning a default value we should be able to create dummy request returning value.

Example:

```python
def foo(val):
     if val is None:
        return Request.with_value(32)

     return Request(_heavy_computational_func)
```
I moved ValueRequest from slot.py because it's functionality relevant only to request users.