### PR TITLE
Reduce number of warnings

### DIFF
--- a/lazyflow/classifiers/tiktorchLazyflowClassifier.py
+++ b/lazyflow/classifiers/tiktorchLazyflowClassifier.py
@@ -335,7 +335,7 @@ class TikTorchLazyflowClassifier(LazyflowPixelwiseClassifierABC):
         logger.debug("Deserializing from {}".format(filename))
 
         with tempfile.TemporaryFile() as f:
-            f.write(h5py_group["classifier"].value)
+            f.write(h5py_group["classifier"][()])
             f.seek(0)
             loaded_pytorch_net = TikTorch.unserialize(f)
 

--- a/lazyflow/operators/ioOperators/UfmfParser.py
+++ b/lazyflow/operators/ioOperators/UfmfParser.py
@@ -135,7 +135,7 @@ class UfmfParser(object):
                 xmin, ymin = intup
 
                 buf = fd.read(chunkimsize)
-                bufim = numpy.fromstring(buf, dtype=numpy.uint8)
+                bufim = numpy.frombuffer(buf, dtype=numpy.uint8)
                 bufim.shape = chunkheight, chunkwidth
                 regions.append((xmin, ymin, bufim))
 
@@ -215,7 +215,7 @@ def _read_array(fd, buf_remaining):
     n_bytes, = struct.unpack("<L", n_bytes_buf)
 
     data_buf, buf_remaining = _read_min_chars(fd, n_bytes, buf_remaining)
-    larr = np.fromstring(data_buf, dtype=dtype_char)
+    larr = np.frombuffer(data_buf, dtype=dtype_char)
     return larr, buf_remaining
 
 
@@ -305,7 +305,7 @@ class UfmfV1(UfmfBase):
         (self._version, self._image_radius, self._timestamp0, self._width, self._height) = intup
         # extract background
         bg_im_buf = self._fd.read(self._width * self._height)
-        self._bg_im = numpy.fromstring(bg_im_buf, dtype=numpy.uint8)
+        self._bg_im = numpy.frombuffer(bg_im_buf, dtype=numpy.uint8)
         self._bg_im.shape = self._height, self._width
         if hasattr(self, "handle_bg"):
             self.handle_bg(self._timestamp0, self._bg_im)
@@ -399,7 +399,7 @@ class UfmfV1(UfmfBase):
                     read_length = chunkwidth * chunkheight
                     bufshape = chunkheight, chunkwidth
                 buf = self._fd.read(read_length)
-                bufim = numpy.fromstring(buf, dtype=numpy.uint8)
+                bufim = numpy.frombuffer(buf, dtype=numpy.uint8)
                 bufim.shape = bufshape
                 regions.append((xmin, ymin, bufim))
             yield timestamp, regions
@@ -456,13 +456,13 @@ class _UFmfV3LowLevelReader(object):
         if self._coding == b"rgb24":
             read_len = width * height * sz * self._bytesperpixel
             buf = self._fd_read(read_len)
-            frame = np.fromstring(buf, dtype=dtype)
+            frame = np.frombuffer(buf, dtype=dtype)
             frame.shape = (3, height, width)
             frame = frame.transpose((1, 2, 0))
         elif self._coding == b"mono8":
             read_len = width * height * sz
             buf = self._fd_read(read_len)
-            frame = np.fromstring(buf, dtype=dtype)
+            frame = np.frombuffer(buf, dtype=dtype)
             frame.shape = (height, width)
         else:
             raise NotImplementedError("Color coding %s not yet implemented" % self._coding)
@@ -488,13 +488,13 @@ class _UFmfV3LowLevelReader(object):
             if self._coding == b"rgb24":
                 lenbuf = w * h * self._bytesperpixel
                 buf = self._fd_read(lenbuf)
-                im = np.fromstring(buf, dtype=np.uint8)
+                im = np.frombuffer(buf, dtype=np.uint8)
                 im.shape = (self._bytesperpixel, h, w)
                 im = im.transpose((1, 2, 0))
             elif self._coding == b"mono8":
                 lenbuf = w * h
                 buf = self._fd_read(lenbuf)
-                im = np.fromstring(buf, dtype=np.uint8)
+                im = np.frombuffer(buf, dtype=np.uint8)
                 im.shape = (h, w)
             else:
                 raise NotImplementedError("Color coding %s not yet implemented" % self._coding)
@@ -551,13 +551,13 @@ class _UFmfV4LowLevelReader(_UFmfV3LowLevelReader):
             # all pixel values.
             lenbuf = n_pts * self._points2_sz
             buf = self._fd_read(lenbuf)
-            locs = np.fromstring(buf, dtype=np.uint16)
+            locs = np.frombuffer(buf, dtype=np.uint16)
             locs.shape = (2, n_pts)
             # the pixel values are indexed by box number, followed by
             # column, followed by row, followed by color
             lenbuf = n_pts * self._w * self._h * self._bytesperpixel
             buf = self._fd_read(lenbuf)
-            im = np.fromstring(buf, dtype=np.uint8)
+            im = np.frombuffer(buf, dtype=np.uint8)
             im.shape = (self._bytesperpixel, self._h, self._w, n_pts)
             im = im.transpose(1, 2, 0, 3)
             # if we need regions to be backwards compatible, we
@@ -579,13 +579,13 @@ class _UFmfV4LowLevelReader(_UFmfV3LowLevelReader):
                 if self._coding == b"rgb24":
                     lenbuf = w * h * self._bytesperpixel
                     buf = self._fd_read(lenbuf)
-                    im = np.fromstring(buf, dtype=np.uint8)
+                    im = np.frombuffer(buf, dtype=np.uint8)
                     im.shape = (self._bytesperpixel, h, w)
                     im = im.transpose((1, 2, 0))
                 elif self._coding == b"mono8":
                     lenbuf = w * h
                     buf = self._fd_read(lenbuf)
-                    im = np.fromstring(buf, dtype=np.uint8)
+                    im = np.frombuffer(buf, dtype=np.uint8)
                     im.shape = (h, w)
                 else:
                     raise NotImplementedError("Color coding %s not yet implemented" % self._coding)

--- a/lazyflow/operators/ioOperators/UfmfParser.py
+++ b/lazyflow/operators/ioOperators/UfmfParser.py
@@ -153,7 +153,7 @@ def identify_ufmf_version(filename):
     if version_buf == b"ufmf":
         version_buf = fd.read(version_buflen)
         had_marker = True
-    version, = struct.unpack(VERSION_FMT, version_buf)
+    (version,) = struct.unpack(VERSION_FMT, version_buf)
     if version > 1:
         if not had_marker:
             raise ValueError("ill-formed .ufmf file")
@@ -212,7 +212,7 @@ def _read_array(fd, buf_remaining):
     n_bytes_calcsize = struct.calcsize("<L")
     x, buf_remaining = _read_min_chars(fd, n_bytes_calcsize, buf_remaining)
     n_bytes_buf = x
-    n_bytes, = struct.unpack("<L", n_bytes_buf)
+    (n_bytes,) = struct.unpack("<L", n_bytes_buf)
 
     data_buf, buf_remaining = _read_min_chars(fd, n_bytes, buf_remaining)
     larr = np.frombuffer(data_buf, dtype=dtype_char)
@@ -228,7 +228,7 @@ def _read_dict(fd, buf_remaining=None):
     Hsize = struct.calcsize("<H")
     for key_num in range(n_keys):
         x, buf_remaining = _read_min_chars(fd, Hsize, buf_remaining)
-        keylen, = struct.unpack("<H", x)
+        (keylen,) = struct.unpack("<H", x)
         x, buf_remaining = _read_min_chars(fd, keylen, buf_remaining)
         key = x
         x, buf_remaining = _read_min_chars(fd, 1, buf_remaining)

--- a/lazyflow/operators/opSimpleBlockedArrayCache.py
+++ b/lazyflow/operators/opSimpleBlockedArrayCache.py
@@ -40,8 +40,8 @@ class OpSimpleBlockedArrayCache(OpUnblockedArrayCache):
         ram_per_pixel = 0
         if self.Input.meta.dtype == object or self.Input.meta.dtype == numpy.object_:
             ram_per_pixel = sys.getsizeof(None)
-        elif numpy.issubdtype(self.Input.meta.dtype, numpy.dtype):
-            ram_per_pixel = self.Input.meta.dtype().nbytes
+        elif numpy.issubdtype(self.Input.meta.dtype, numpy.generic):
+            ram_per_pixel = numpy.dtype(self.Input.meta.dtype).itemsize
 
         # One 'pixel' includes all channels
         tagged_shape = self.Input.meta.getTaggedShape()

--- a/lazyflow/operators/opSlicedBlockedArrayCache.py
+++ b/lazyflow/operators/opSlicedBlockedArrayCache.py
@@ -138,8 +138,8 @@ class OpSlicedBlockedArrayCache(Operator, ObservableCache):
         ram_per_pixel = 0
         if self.Output.meta.dtype == object or self.Output.meta.dtype == numpy.object_:
             ram_per_pixel = sys.getsizeof(None)
-        elif numpy.issubdtype(self.Output.meta.dtype, numpy.dtype):
-            ram_per_pixel = self.Output.meta.dtype().nbytes
+        elif numpy.issubdtype(self.Output.meta.dtype, numpy.generic):
+            ram_per_pixel = numpy.dtype(self.Input.meta.dtype).itemsize
 
         tagged_shape = self.Output.meta.getTaggedShape()
         if "c" in tagged_shape:

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -1108,7 +1108,6 @@ class Slot(object):
                             # in which case we assume the values are different
                             same = False
 
-                        assert isinstance(same, bool)
                     changed = not same
 
             if changed:

--- a/lazyflow/slot.py
+++ b/lazyflow/slot.py
@@ -1102,13 +1102,13 @@ class Slot(object):
                     same = value is self._value
                     if not same:
                         try:
-                            same = value == self._value
+                            same = numpy.array_equal(value, self._value)
                         except ValueError:
                             # Some values can't be compared with __eq__,
                             # in which case we assume the values are different
                             same = False
-                        if isinstance(same, (numpy.ndarray, TinyVector)):
-                            same = same.all()
+
+                        assert isinstance(same, bool)
                     changed = not same
 
             if changed:


### PR DESCRIPTION
On a quest in reducing noise in tests, and in ilastik in general I've tackled most warnings issued by dependencies. Warning count went down from 188 to 24 when running the tests.

Warnings removed:

* `numpy`:
  * DeprecationWarning: The binary mode of fromstring is deprecated
  * FutureWarning: Conversion of the second argument of issubdtype from `dtype` to `np.generic` is deprecated. In future, it will be treated as `np.object_ == np.dtype(dtype).type`.
  * DeprecationWarning: elementwise == comparison failed; this will raise an error in the future.
* `h5py`:
  * H5pyDeprecationWarning: dataset.value has been deprecated. Use dataset[()] instead.

I'm doing the same in the other repos while I'm at it. Now it's easier to concentrate on our own warnings...

btw. `numpy.array_equal` (and it's sister `numpy.array_equiv`) are awesome, didn't know them before. Those functions eat almost anything